### PR TITLE
Stabilized description printing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+The Labyrinth of Time's Edge.exe

--- a/The Labyrinth of Time's Edge.BAS
+++ b/The Labyrinth of Time's Edge.BAS
@@ -227,20 +227,20 @@ Do
     Print ""
     Print ""
     If rooms(r).northExit > 0 Then
-        CenterPrint("N")
-    ELSE
-        CenterPrint(" ")
-    END IF
+        CenterPrint ("N")
+    Else
+        CenterPrint (" ")
+    End If
     PartA$ = " "
     PartB$ = " "
     If rooms(r).westExit > 0 Then PartA$ = "W"
     If rooms(r).eastExit > 0 Then PartB$ = "E"
-    CenterPrintWithLine(PartA$ + " + " + PartB$)
+    CenterPrintWithLine (PartA$ + " + " + PartB$)
     If rooms(r).southExit > 0 Then
-        CenterPrint("S")
-    ELSE
-        CenterPrint(" ")
-    END IF
+        CenterPrint ("S")
+    Else
+        CenterPrint (" ")
+    End If
     Print ""
     Print "If you are stuck just type HELP."
     Print
@@ -256,7 +256,7 @@ If paddingLen < 0 Then paddingLen = 0 ' Prevent negative padding
 
 ' Print formatted title and description
 Print "__"; rooms(r).title; String$(paddingLen, "_") ' Replicates __Title______ format
-Print rooms(r).description
+PrintWrapSafe(rooms(r).description)
 Print "_______________________________________________________________________________"
 
 Return
@@ -6808,3 +6808,93 @@ Sub CenterPrintWithLine (Text$) ' This function will print text center with a li
     Print String$(80, "-");
     CenterPrint(Text$)
 End Sub
+
+SUB PrintWrapSafe (Text$)
+    DIM CurrentPos AS INTEGER
+    DIM LineWidth AS INTEGER
+    DIM MaxLength AS INTEGER
+    DIM CurrentLine AS STRING
+    DIM NextWord AS STRING
+    DIM WordStart AS INTEGER
+    DIM WordEnd AS INTEGER
+    DIM PotentialLength AS INTEGER
+    DIM FirstWordOnLine AS INTEGER ' Boolean-like flag: 1 = True, 0 = False
+
+    MaxLength = 80 ' Set the desired maximum line length (adjust as needed)
+    LineWidth = LEN(Text$)
+    CurrentPos = 1
+    CurrentLine = ""
+    FirstWordOnLine = 1 ' True initially, prevents leading space on first line
+
+    WHILE CurrentPos <= LineWidth
+        ' --- Step 1: Find the start of the next word (skip spaces) ---
+        WHILE CurrentPos <= LineWidth AND MID$(Text$, CurrentPos, 1) = " "
+            CurrentPos = CurrentPos + 1
+        WEND
+        IF CurrentPos > LineWidth THEN EXIT WHILE ' Exit if only trailing spaces were left
+
+        WordStart = CurrentPos
+
+        ' --- Step 2: Find the end of the current word ---
+        ' Scan until the next space or the end of the entire text string
+        WordEnd = WordStart
+        WHILE WordEnd <= LineWidth AND MID$(Text$, WordEnd, 1) <> " "
+            WordEnd = WordEnd + 1
+        WEND
+        ' WordEnd now points AT the space after the word, or just PAST the end of Text$
+        WordEnd = WordEnd - 1 ' Adjust to point to the last character OF the word
+
+        ' --- Step 3: Extract the word ---
+        IF WordEnd >= WordStart THEN
+            NextWord = MID$(Text$, WordStart, WordEnd - WordStart + 1)
+        ELSE
+             ' This case should ideally not be reached if logic is sound
+             EXIT WHILE
+        END IF
+
+        ' --- Step 4: Check if the extracted word fits on the current line ---
+        IF FirstWordOnLine = 1 THEN
+            ' If it's the first word, it just needs to fit by itself
+            PotentialLength = LEN(NextWord)
+        ELSE
+            ' Otherwise, need space for current line, a space, and the new word
+            PotentialLength = LEN(CurrentLine) + 1 + LEN(NextWord)
+        END IF
+
+        IF PotentialLength <= MaxLength THEN
+            ' --- Word Fits: Append it to the current line ---
+            IF FirstWordOnLine = 1 THEN
+                CurrentLine = NextWord
+                FirstWordOnLine = 0 ' It's no longer the first word for the next check
+            ELSE
+                CurrentLine = CurrentLine + " " + NextWord
+            END IF
+            ' Advance position past the word we just processed
+            CurrentPos = WordEnd + 1
+        ELSE
+            ' --- Word Does NOT Fit: Print the current line and start new one ---
+            PRINT CurrentLine
+
+            ' The word that didn't fit becomes the start of the new line
+            CurrentLine = NextWord
+            FirstWordOnLine = 0 ' It's the first word added, but don't add space before next
+
+            ' Handle edge case: A single word is longer than MaxLength
+            ' In this simple version, it will be printed on its own line, exceeding MaxLength.
+            ' More complex logic could break the word here if needed.
+            IF LEN(CurrentLine) > MaxLength THEN
+                ' PRINT "*** Warning: Word exceeds MaxLength ***" ' Optional warning
+            END IF
+
+            ' Advance position past the word we just processed
+            CurrentPos = WordEnd + 1
+        END IF
+
+    WEND ' Loop back to process the next word
+
+    ' --- After the loop, print any remaining text in the CurrentLine buffer ---
+    IF LEN(CurrentLine) > 0 THEN
+        PRINT CurrentLine
+    END IF
+
+END SUB

--- a/rooms.txt
+++ b/rooms.txt
@@ -1,9003 +1,7330 @@
 --ROOM 1 START--
 Village of Oathmoor
 2,0,0,0
-   You stand before the entrance to a once-thriving place, its former vibrancy
- now consumed by an air of mystery and decay. What secrets or dangers might lie
- within remain unknown.
+You stand before the entrance to a once-thriving place, its former vibrancy now consumed by an air of mystery and decay. What secrets or dangers might lie within remain unknown.
 --ROOM 1 END--
 --ROOM 2 START--
 Village of Oathmoor
 14,1,3,0
-   The hollow streets stretch before you, their emptiness pierced by the wail of
- the wind. A cold shiver crawls up your spine as the desolation seeps into your
- bones.
+The hollow streets stretch before you, their emptiness pierced by the wail of the wind. A cold shiver crawls up your spine as the desolation seeps into your bones.
 --ROOM 2 END--
 --ROOM 3 START--
 Village of Oathmoor
 0,0,4,2
-   Weathered and abandoned, the buildings around you lean like forgotten
- sentinels. Their boarded windows and doors seem to guard stories of neglect and
- sorrow.
+Weathered and abandoned, the buildings around you lean like forgotten sentinels. Their boarded windows and doors seem to guard stories of neglect and sorrow.
 --ROOM 3 END--
 --ROOM 4 START--
 Village of Oathmoor
 0,0,5,3
-   Footsteps echo faintly through the stillness, yet the source remains unseen.
- Ghostly figures pale and fleeting drift through the misty ruins, adding an
- eerie vitality to the wasteland.
+Footsteps echo faintly through the stillness, yet the source remains unseen. Ghostly figures pale and fleeting drift through the misty ruins, adding an eerie vitality to the wasteland.
 --ROOM 4 END--
 --ROOM 5 START--
 Village of Oathmoor
 6,0,0,4
-   A biting chill lingers in the air, wrapping itself around you as you tread
- through this graveyard of forsaken buildings. Their skeletal remains whisper of
- memories long extinguished.
+A biting chill lingers in the air, wrapping itself around you as you tread through this graveyard of forsaken buildings. Their skeletal remains whisper of memories long extinguished.
 --ROOM 5 END--
 --ROOM 6 START--
 Village of Oathmoor
 8,5,7,0
-   A sudden, jarring slam of a door shatters the silence, jolting you from your
- thoughts. The sound reverberates like a warning or perhaps a call.
+A sudden, jarring slam of a door shatters the silence, jolting you from your thoughts. The sound reverberates like a warning or perhaps a call.
 --ROOM 6 END--
 --ROOM 7 START--
 Village of Oathmoor
 0,0,0,6
-   Distant laughter echoes through the air, hollow and strange. Suddenly, you
- are met by the imposing presence of a King's Guard, his gaze unwavering as he
- blocks your path.
+Distant laughter echoes through the air, hollow and strange. Suddenly, you are met by the imposing presence of a King's Guard, his gaze unwavering as he blocks your path.
 --ROOM 7 END--
 --ROOM 8 START--
 Village of Oathmoor
 10,6,0,9
-   Everywhere you look-on walls and cobblestone streets-are crude, mocking
- depictions of the King. The graffiti speaks of rebellion, dissent, or perhaps
- the people's desperate need for release.
+Everywhere you look-on walls and cobblestone streets-are crude, mocking depictions of the King. The graffiti speaks of rebellion, dissent, or perhaps the people's desperate need for release.
 --ROOM 8 END--
 --ROOM 9 START--
 Village of Oathmoor
 0,0,8,0
-   The path leads to an abrupt and lifeless dead end. Heaps of trash and debris
- sit undisturbed, their stench of abandonment thick and oppressive.
+The path leads to an abrupt and lifeless dead end. Heaps of trash and debris sit undisturbed, their stench of abandonment thick and oppressive.
 --ROOM 9 END--
 --ROOM 10 START--
 Village of Oathmoor
 12,8,11,0
-   Figures cloaked in shadow wander aimlessly, their hands the only part of them
- exposed. They mutter incessantly, their voices weaving an ominous symphony of
- whispered prayers.
+Figures cloaked in shadow wander aimlessly, their hands the only part of them exposed. They mutter incessantly, their voices weaving an ominous symphony of whispered prayers.
 --ROOM 10 END--
 --ROOM 11 START--
 Village of Oathmoor
 0,0,0,10
-   Abandoned carts, once brimming with the bounty of nearby farms, now lie empty
- and broken. They stand as relics of a more prosperous past, now just echoes of
- better days.
+Abandoned carts, once brimming with the bounty of nearby farms, now lie empty and broken. They stand as relics of a more prosperous past, now just echoes of better days.
 --ROOM 11 END--
 --ROOM 12 START--
 Village of Oathmoor
 13,10,0,0
-   The further you walk, the more the homes crumble. Dilapidation gives way to
- outright ruin until nothing remains but piles of rubble-silent monuments to
- collapse and neglect.
+The further you walk, the more the homes crumble. Dilapidation gives way to outright ruin until nothing remains but piles of rubble-silent monuments to collapse and neglect.
 --ROOM 12 END--
 --ROOM 13 START--
 Village of Oathmoor
 0,12,0,0
-   At the base of a weatherworn stone statue, you stand in quiet reverence. The
- figure of a hero, once celebrated, is now scarcely remembered-a fading symbol
- of a bygone era.
+At the base of a weatherworn stone statue, you stand in quiet reverence. The figure of a hero, once celebrated, is now scarcely remembered-a fading symbol of a bygone era.
 --ROOM 13 END--
 --ROOM 14 START--
 Village of Oathmoor
 15,2,0,0
-   You tread carefully along a once-bustling street, its faded cobblestones
- whispering tales of a forgotten past. What was once the lifeblood of this
- place now lies dormant, shrouded in the weight of memory.
+You tread carefully along a once-bustling street, its faded cobblestones whispering tales of a forgotten past. What was once the lifeblood of this place now lies dormant, shrouded in the weight of memory.
 --ROOM 14 END--
 --ROOM 15 START--
 Village of Oathmoor
 20,14,0,16
-   Pale, expressionless faces drift aimlessly in the thick haze, lost souls
- caught in a silent, eternal wandering. Their presence chills the air around
- you.
+Pale, expressionless faces drift aimlessly in the thick haze, lost souls caught in a silent, eternal wandering. Their presence chills the air around you.
 --ROOM 15 END--
 --ROOM 16 START--
 Village of Oathmoor
 0,0,15,17
-   An old church, weathered but oddly preserved, stands solemnly atop a plot of
- land untouched by the chaos of time. Its quiet dignity beckons you closer.
+An old church, weathered but oddly preserved, stands solemnly atop a plot of land untouched by the chaos of time. Its quiet dignity beckons you closer.
 --ROOM 16 END--
 --ROOM 17 START--
 Village of Oathmoor
 0,18,16,0
-   Splintered wooden fences, built by hands long gone, crumble into decay. The
- air thickens with a heavy, almost tangible presence of time's relentless
- march.
+Splintered wooden fences, built by hands long gone, crumble into decay. The air thickens with a heavy, almost tangible presence of time's relentless march.
 --ROOM 17 END--
 --ROOM 18 START--
 Village of Oathmoor
 17,0,0,19
-   An old man moves soundlessly along the deserted street, his hand cart
- creaking faintly in the silence. He seems oblivious to the world around him.
+An old man moves soundlessly along the deserted street, his hand cart creaking faintly in the silence. He seems oblivious to the world around him.
 --ROOM 18 END--
 --ROOM 19 START--
 Village of Oathmoor
 0,0,18,0
-   Your path is abruptly blocked by a mound of rubble, a grim reminder of the
- fragility of the structures that once stood tall here.
+Your path is abruptly blocked by a mound of rubble, a grim reminder of the fragility of the structures that once stood tall here.
 --ROOM 19 END--
 --ROOM 20 START--
 Village of Oathmoor
 21,15,0,0
-   A sudden flash of lightning splits the sky, casting the world into stark
- relief. Shadows leap and twist in the fleeting brightness, dancing to the
- rhythm of the storm.
+A sudden flash of lightning splits the sky, casting the world into stark relief. Shadows leap and twist in the fleeting brightness, dancing to the rhythm of the storm.
 --ROOM 20 END--
 --ROOM 21 START--
 Village of Oathmoor
 0,20,22,29
-   A pillar of smoke spirals skyward, cutting through the gloom. Children laugh
- and play amidst the ruins of the decaying village, their joy hauntingly at
- odds with their surroundings.
+A pillar of smoke spirals skyward, cutting through the gloom. Children laugh and play amidst the ruins of the decaying village, their joy hauntingly at odds with their surroundings.
 --ROOM 21 END--
 --ROOM 22 START--
 Village of Oathmoor
 23,0,0,21
-   You find yourself in a narrow, dimly lit alley. An elderly woman sits
- perched on a broken stool, her piercing gaze fixed on you with an unsettling
- intensity.
+You find yourself in a narrow, dimly lit alley. An elderly woman sits perched on a broken stool, her piercing gaze fixed on you with an unsettling intensity.
 --ROOM 22 END--
 --ROOM 23 START--
 Village of Oathmoor
 24,22,0,0
-   The road ahead begins to slope gently upward, winding its way past
- abandoned, barren buildings whose windows gape like empty eyes.
+The road ahead begins to slope gently upward, winding its way past abandoned, barren buildings whose windows gape like empty eyes.
 --ROOM 23 END--
 --ROOM 24 START--
 Village of Oathmoor
 0,23,25,0
-   The eerie stillness around you is oppressive, broken only by the creeping
- sensation of unseen eyes upon you. A chill snakes down your spine.
+The eerie stillness around you is oppressive, broken only by the creeping sensation of unseen eyes upon you. A chill snakes down your spine.
 --ROOM 24 END--
 --ROOM 25 START--
 Village of Oathmoor
 26,0,0,24
-   A faint melody drifts toward you, its haunting notes carried on the breeze.
- The aroma of a meal cooking over a distant fire stirs both hunger and
- curiosity.
+A faint melody drifts toward you, its haunting notes carried on the breeze. The aroma of a meal cooking over a distant fire stirs both hunger and curiosity.
 --ROOM 25 END--
 --ROOM 26 START--
 Village of Oathmoor
 27,25,0,0
-   You stumble upon a makeshift camp where people dance in defiance of their
- sorrows. The leader of this ragtag group locks eyes with you, their expression
- unreadable.
+You stumble upon a makeshift camp where people dance in defiance of their sorrows. The leader of this ragtag group locks eyes with you, their expression unreadable.
 --ROOM 26 END--
 --ROOM 27 START--
 Village of Oathmoor
 0,26,28,0
-   Hand-carved stone bowls, once brimming with offerings of fruit and
- vegetables, sit abandoned. Their purpose-and their recipient-are now mysteries
- lost to time.
+Hand-carved stone bowls, once brimming with offerings of fruit and vegetables, sit abandoned. Their purpose-and their recipient-are now mysteries lost to time.
 --ROOM 27 END--
 --ROOM 28 START--
 Village of Oathmoor
 0,0,47,27
-   Before you looms the entrance to the enigmatic Lumirath Cave, its yawning
- maw promising both wonder and peril.
+Before you looms the entrance to the enigmatic Lumirath Cave, its yawning maw promising both wonder and peril.
 --ROOM 28 END--
 --ROOM 29 START--
 Village of Oathmoor
 30,0,21,0
-   A crow's mournful cry pierces the air as you wander this desolate place. Its
- echo lingers, a sound both ominous and strangely alive.
+A crow's mournful cry pierces the air as you wander this desolate place. Its echo lingers, a sound both ominous and strangely alive.
 --ROOM 29 END--
 --ROOM 30 START--
 Village of Oathmoor
 33,29,0,31
-   As you tread cautiously down the road, a figure in white appears. The woman
- paces back and forth, her anxious steps portraying a restless anticipation.
+As you tread cautiously down the road, a figure in white appears. The woman paces back and forth, her anxious steps portraying a restless anticipation.
 --ROOM 30 END--
 --ROOM 31 START--
 Village of Oathmoor
 0,0,30,32
-   Rusted iron fences stretch solemnly across the landscape, separating the
- world of the living from the eternal rest of the departed.
+Rusted iron fences stretch solemnly across the landscape, separating the world of the living from the eternal rest of the departed.
 --ROOM 31 END--
 --ROOM 32 START--
 Village of Oathmoor
 0,0,31,113
-   The cemetery gate creaks softly, swaying in rhythm with the gentle breeze,
- as though it carries whispers from another realm.
+The cemetery gate creaks softly, swaying in rhythm with the gentle breeze, as though it carries whispers from another realm.
 --ROOM 32 END--
 --ROOM 33 START--
 Village of Oathmoor
 34,30,0,0
-   Homes with boarded windows and tightly sealed doors seem to shun the outside
- world, as if warding off unwelcome spirits.
+Homes with boarded windows and tightly sealed doors seem to shun the outside world, as if warding off unwelcome spirits.
 --ROOM 33 END--
 --ROOM 34 START--
 Village of Oathmoor
 0,33,0,35
-   Standing before a battered gate, you find yourself face to face with a stoic
- Guard clad in the armor of the King's army.
+Standing before a battered gate, you find yourself face to face with a stoic Guard clad in the armor of the King's army.
 --ROOM 34 END--
 --ROOM 35 START--
 Village of Oathmoor
 36,0,34,0
-   The few souls who still call this forsaken place home wander the streets,
- their eyes scanning for whatever scraps of hope or sustenance they can find.
+The few souls who still call this forsaken place home wander the streets, their eyes scanning for whatever scraps of hope or sustenance they can find.
 --ROOM 35 END--
 --ROOM 36 START--
 Village of Oathmoor
 37,35,0,0
-   A Fortune Teller blocks your path, her piercing gaze locking onto yours as
- she delivers an unsettling prophecy in hushed tones.
+A Fortune Teller blocks your path, her piercing gaze locking onto yours as she delivers an unsettling prophecy in hushed tones.
 --ROOM 36 END--
 --ROOM 37 START--
 Village of Oathmoor
 0,36,38,0
-   Abandoned wagons line the path, as if their owners fled in haste-yet the
- cause of their flight remains a chilling mystery.
+Abandoned wagons line the path, as if their owners fled in haste-yet the cause of their flight remains a chilling mystery.
 --ROOM 37 END--
 --ROOM 38 START--
 Village of Oathmoor
 0,0,39,37
-   Crumbling stone walls flank your route, remnants of a long-past invasion
- that failed to bring them down entirely.
+Crumbling stone walls flank your route, remnants of a long-past invasion that failed to bring them down entirely.
 --ROOM 38 END--
 --ROOM 39 START--
 Village of Oathmoor
 40,0,0,38
-   The earth bears the scars of ancient battles, with craters and forgotten
- trenches marking a landscape still haunted by war.
+The earth bears the scars of ancient battles, with craters and forgotten trenches marking a landscape still haunted by war.
 --ROOM 39 END--
 --ROOM 40 START--
 Village of Oathmoor
 0,39,41,0
-   A sturdy wooden bridge spans a shallow river below, its weathered planks
- creaking beneath the weight of countless crossings.
+A sturdy wooden bridge spans a shallow river below, its weathered planks creaking beneath the weight of countless crossings.
 --ROOM 40 END--
 --ROOM 41 START--
 Village of Oathmoor
 0,0,42,40
-   Gray, expressionless faces pass you by, remnants of once-joyful villagers
- now consumed by an oppressive, unholy pall.
+Gray, expressionless faces pass you by, remnants of once-joyful villagers now consumed by an oppressive, unholy pall.
 --ROOM 41 END--
 --ROOM 42 START--
 Village of Oathmoor
 43,0,0,41
-   The winding path ahead leads upward, toward the imposing entrance of the
- castle looming on the horizon.
+The winding path ahead leads upward, toward the imposing entrance of the castle looming on the horizon.
 --ROOM 42 END--
 --ROOM 43 START--
 Village of Oathmoor
 44,42,0,0
-   The eyes of the King's Guard follow your every move as you approach the
- immense wooden doors that bar your way.
+The eyes of the King's Guard follow your every move as you approach the immense wooden doors that bar your way.
 --ROOM 43 END--
 --ROOM 44 START--
 Village of Oathmoor
 45,43,0,0
-   ôHalt!ö A commanding voice booms, cutting through the stillness. A stern
- Guard demands to know your purpose with the King.
+ôHalt!ö A commanding voice booms, cutting through the stillness. A stern Guard demands to know your purpose with the King.
 --ROOM 44 END--
 --ROOM 45 START--
 Village of Oathmoor
 46,44,0,0
-   Thick stone walls enclose you, muffling the world outside as you traverse a
- series of heavily guarded checkpoints.
+Thick stone walls enclose you, muffling the world outside as you traverse a series of heavily guarded checkpoints.
 --ROOM 45 END--
 --ROOM 46 START--
 Village of Oathmoor
 176,45,0,0
-   At last, you stand before the final set of doors. As they creak open, you
- are met with the desolate grandeur of a fallen kingdom.
+At last, you stand before the final set of doors. As they creak open, you are met with the desolate grandeur of a fallen kingdom.
 --ROOM 46 END--
 --ROOM 47 START--
 Lumirath Cave
 0,0,48,28
-   You descend into an uncharted world beneath the Earth, where shadows loom
- and secrets whisper in the stillness.
+You descend into an uncharted world beneath the Earth, where shadows loom and secrets whisper in the stillness.
 --ROOM 47 END--
 --ROOM 48 START--
 Lumirath Cave
 0,49,0,47
-   The walls bear the scars of countless pickaxe strikes, their jagged marks
- telling stories of toil from a forgotten era.
+The walls bear the scars of countless pickaxe strikes, their jagged marks telling stories of toil from a forgotten era.
 --ROOM 48 END--
 --ROOM 49 START--
 Lumirath Cave
 48,0,50,0
-   The deeper you journey into the labyrinthine abyss, the more you sense
- unseen eyes watching from the cracks in the walls.
+The deeper you journey into the labyrinthine abyss, the more you sense unseen eyes watching from the cracks in the walls.
 --ROOM 49 END--
 --ROOM 50 START--
 Lumirath Cave
 0,0,51,49
-   A steady *drip... drip... drip* echoes in the darkness, the sound of water
- falling into unseen pools beneath your feet.
+A steady *drip... drip... drip* echoes in the darkness, the sound of water falling into unseen pools beneath your feet.
 --ROOM 50 END--
 --ROOM 51 START--
 Lumirath Cave
 0,52,0,50
-   From the shadows ahead, faint laughter ripples through the air-only to
- dissolve into a blood-curdling scream that freezes you in place.
+From the shadows ahead, faint laughter ripples through the air-only to dissolve into a blood-curdling scream that freezes you in place.
 --ROOM 51 END--
 --ROOM 52 START--
 Lumirath Cave
 51,0,53,0
-   A haphazard collection of furniture cobbled together from weathered hides
- and scavenged wood lies scattered here, a testament to survival in the depths.
+A haphazard collection of furniture cobbled together from weathered hides and scavenged wood lies scattered here, a testament to survival in the depths.
 --ROOM 52 END--
 --ROOM 53 START--
 Lumirath Cave
 0,0,54,52
-   By the flickering glow of a makeshift fire, a weary miner stares into the
- flames, his hollow eyes portraying years of solitude.
+By the flickering glow of a makeshift fire, a weary miner stares into the flames, his hollow eyes portraying years of solitude.
 --ROOM 53 END--
 --ROOM 54 START--
 Lumirath Cave
 57,0,55,53
-   You stand at the edge of an ever-descending realm, where darkness stretches
- endlessly into the unknown.
+You stand at the edge of an ever-descending realm, where darkness stretches endlessly into the unknown.
 --ROOM 54 END--
 --ROOM 55 START--
 Lumirath Cave
 0,0,56,54
-   The oppressive silence amplifies every hesitant step you take, the uneven
- floor threatening to betray your footing.
+The oppressive silence amplifies every hesitant step you take, the uneven floor threatening to betray your footing.
 --ROOM 55 END--
 --ROOM 56 START--
 Lumirath Cave
 0,0,0,55
-   A dead end looms before you, but amidst the debris, you spot an old,
- dust-covered diary waiting to reveal its secrets.
+A dead end looms before you, but amidst the debris, you spot an old, dust-covered diary waiting to reveal its secrets.
 --ROOM 56 END--
 --ROOM 57 START--
 Lumirath Cave
 58,54,0,0
-   The tunnel floor steepens dangerously, each step requiring careful balance
- as you hold your breath to avoid a deadly slip.
+The tunnel floor steepens dangerously, each step requiring careful balance as you hold your breath to avoid a deadly slip.
 --ROOM 57 END--
 --ROOM 58 START--
 Lumirath Cave
 59,57,0,0
-   The ground trembles beneath your feet, and with a grinding rumble, the rock
- face splits open, revealing a concealed door.
+The ground trembles beneath your feet, and with a grinding rumble, the rock face splits open, revealing a concealed door.
 --ROOM 58 END--
 --ROOM 59 START--
 Lumirath Cave
 62,58,60,0
-   A cloaked figure blocks your path, their presence unnervingly calm-as if
- they've been waiting for your arrival.
+A cloaked figure blocks your path, their presence unnervingly calm-as if they've been waiting for your arrival.
 --ROOM 59 END--
 --ROOM 60 START--
 Lumirath Cave
 0,0,61,59
-   A golden statue stands before you, arms outstretched in a gesture of
- welcome, infusing this place with an unexpected warmth that feels like home.
+A golden statue stands before you, arms outstretched in a gesture of welcome, infusing this place with an unexpected warmth that feels like home.
 --ROOM 60 END--
 --ROOM 61 START--
 Lumirath Cave
 0,0,0,60
-   You stand at the edge of a vast chasm shrouded in impenetrable darkness. The
- faint, eerie call of a bat echoes through the void, sending a chill down your
- spine.
+You stand at the edge of a vast chasm shrouded in impenetrable darkness. The faint, eerie call of a bat echoes through the void, sending a chill down your spine.
 --ROOM 61 END--
 --ROOM 62 START--
 Lumirath Cave
 0,59,0,63
-   The rocky pathway winds unpredictably, twisting and turning until you arrive
- before a crude, precarious bridge swaying gently in an unseen breeze.
+The rocky pathway winds unpredictably, twisting and turning until you arrive before a crude, precarious bridge swaying gently in an unseen breeze.
 --ROOM 62 END--
 --ROOM 63 START--
 Lumirath Cave
 64,0,62,0
-   A cool gust of air whispers past, carrying with it an uncanny silence that
- presses against you like an invisible weight.
+A cool gust of air whispers past, carrying with it an uncanny silence that presses against you like an invisible weight.
 --ROOM 63 END--
 --ROOM 64 START--
 Lumirath Cave
 65,63,0,0
-   The bridge creaks ominously beneath your hesitant steps, each one a gamble
- against its fragile structure, which threatens to collapse at any moment.
+The bridge creaks ominously beneath your hesitant steps, each one a gamble against its fragile structure, which threatens to collapse at any moment.
 --ROOM 64 END--
 --ROOM 65 START--
 Lumirath Cave
 0,64,66,0
-   Having crossed to the far side, the faint murmur of distant voices drifts
- toward you, beckoning with both curiosity and unease.
+Having crossed to the far side, the faint murmur of distant voices drifts toward you, beckoning with both curiosity and unease.
 --ROOM 65 END--
 --ROOM 66 START--
 Lumirath Cave
 67,0,0,65
-   You creep through the shadowy tunnel, your steps muffled against the damp
- stone. Ahead, the flicker of firelight dances across the walls, illuminating
- fragments of whispered conversation.
+You creep through the shadowy tunnel, your steps muffled against the damp stone. Ahead, the flicker of firelight dances across the walls, illuminating fragments of whispered conversation.
 --ROOM 66 END--
 --ROOM 67 START--
 Lumirath Cave
 68,66,0,0
-   As you inch closer, you pause to wonder: friend or foe? Before the thought
- can settle, a hulking figure steps into view-a snarling Orc, its eyes locking
- onto yours.
+As you inch closer, you pause to wonder: friend or foe? Before the thought can settle, a hulking figure steps into view-a snarling Orc, its eyes locking onto yours.
 --ROOM 67 END--
 --ROOM 68 START--
 Lumirath Cave
 0,67,69,73
-   The pungent stench of decay assaults your senses, an unmistakable sign of a
- Mothrat nest nearby.
+The pungent stench of decay assaults your senses, an unmistakable sign of a Mothrat nest nearby.
 --ROOM 68 END--
 --ROOM 69 START--
 Lumirath Cave
 0,70,0,68
-   The air grows humid and oppressive as you approach the source of the foul
- odor. Each breath feels heavier, laden with the weight of the cave's unseen
- menace.
+The air grows humid and oppressive as you approach the source of the foul odor. Each breath feels heavier, laden with the weight of the cave's unseen menace.
 --ROOM 69 END--
 --ROOM 70 START--
 Lumirath Cave
 69,72,71,0
-   Beads of sweat gather on your brow as the heat becomes almost unbearable. A
- strange, rhythmic humming reverberates through the cavern, unnerving and
- incessant.
+Beads of sweat gather on your brow as the heat becomes almost unbearable. A strange, rhythmic humming reverberates through the cavern, unnerving and incessant.
 --ROOM 70 END--
 --ROOM 71 START--
 Lumirath Cave
 0,0,0,70
-   You freeze in place, confronted by a sprawling, pulsating Mothrat nest. The
- creatures scuttle across the grotesque structure, their movements an
- unsettling harmony of chaos.
+You freeze in place, confronted by a sprawling, pulsating Mothrat nest. The creatures scuttle across the grotesque structure, their movements an unsettling harmony of chaos.
 --ROOM 71 END--
 --ROOM 72 START--
 Lumirath Cave
 70,0,0,0
-   You find yourself at a dead end. A stone wall blocks your path, etched with
- cryptic symbols and a message carved deep into its surface.
+You find yourself at a dead end. A stone wall blocks your path, etched with cryptic symbols and a message carved deep into its surface.
 --ROOM 72 END--
 --ROOM 73 START--
 Lumirath Cave
 0,0,68,74
-   The narrow staircase descends steeply, leading you further into the abyss.
- Shadows cling to the walls, seemingly alive with anticipation.
+The narrow staircase descends steeply, leading you further into the abyss. Shadows cling to the walls, seemingly alive with anticipation.
 --ROOM 73 END--
 --ROOM 74 START--
 Lumirath Cave
 0,0,73,75
-   Your lantern's glow reveals a cavernous hall. Towering carved pillars reach
- toward the ceiling, while an enormous stone head looms above, its lifeless
- eyes gazing downward in eternal judgment.
+Your lantern's glow reveals a cavernous hall. Towering carved pillars reach toward the ceiling, while an enormous stone head looms above, its lifeless eyes gazing downward in eternal judgment.
 --ROOM 74 END--
 --ROOM 75 START--
 Lumirath Cave
 76,0,74,0
-   A grand fountain stands before you, its waters still flowing from a hidden
- spring. Despite the passage of time, this sacred place appears lovingly
- maintained by unseen hands, a testament to the devotion of those who came
- before.
+A grand fountain stands before you, its waters still flowing from a hidden spring. Despite the passage of time, this sacred place appears lovingly maintained by unseen hands, a testament to the devotion of those who came before.
 --ROOM 75 END--
 --ROOM 76 START--
 Lumirath Cave
 77,75,0,0
-   Majestic statues are scattered throughout the clearing, their weathered
- forms depicting ancient gods or perhaps long-forgotten kings. Their silent
- gazes seem to follow your every move.
+Majestic statues are scattered throughout the clearing, their weathered forms depicting ancient gods or perhaps long-forgotten kings. Their silent gazes seem to follow your every move.
 --ROOM 76 END--
 --ROOM 77 START--
 Lumirath Cave
 79,76,81,78
-   The ground beneath your feet softens, giving way to rich, loamy soil.
- Towering trees stretch overhead, their leafy canopy casting dappled shadows
- across the forest floor.
+The ground beneath your feet softens, giving way to rich, loamy soil. Towering trees stretch overhead, their leafy canopy casting dappled shadows across the forest floor.
 --ROOM 77 END--
 --ROOM 78 START--
 Lumirath Cave
 0,0,77,0
-   You arrive at an abandoned camp, its smoldering fire reduced to glowing
- embers. A simple bedroll and a weathered sack remain, but the owner is nowhere
- to be seen.
+You arrive at an abandoned camp, its smoldering fire reduced to glowing embers. A simple bedroll and a weathered sack remain, but the owner is nowhere to be seen.
 --ROOM 78 END--
 --ROOM 79 START--
 Lumirath Cave
 80,77,0,0
-   The air grows thick with humidity as the lush vegetation closes in around
- you. The oppressive heat clings to your skin, and the sound of unseen
- creatures stirs in the distance.
+The air grows thick with humidity as the lush vegetation closes in around you. The oppressive heat clings to your skin, and the sound of unseen creatures stirs in the distance.
 --ROOM 79 END--
 --ROOM 80 START--
 Lumirath Cave
 0,79,0,0
-   The dense undergrowth abruptly ends, revealing a massive slab of rock before
- you. Its smooth, unyielding surface stands in stark contrast to the wild
- terrain behind you.
+The dense undergrowth abruptly ends, revealing a massive slab of rock before you. Its smooth, unyielding surface stands in stark contrast to the wild terrain behind you.
 --ROOM 80 END--
 --ROOM 81 START--
 Lumirath Cave
 0,0,82,77
-   With each cautious step, you venture deeper into an underground jungle, its
- vibrant yet shadowy foliage pulsing with life unknown.
+With each cautious step, you venture deeper into an underground jungle, its vibrant yet shadowy foliage pulsing with life unknown.
 --ROOM 81 END--
 --ROOM 82 START--
 Lumirath Cave
 83,0,0,81
-   Gnarled roots twist and writhe up from the earth, their slow, deliberate
- movements almost as if they're searching for something-or someone.
+Gnarled roots twist and writhe up from the earth, their slow, deliberate movements almost as if they're searching for something-or someone.
 --ROOM 82 END--
 --ROOM 83 START--
 Lumirath Cave
 0,82,84,0
-   At your feet lies a torn, weathered tent, its fabric fraying with age.
- Nearby, trees have been cut and stripped, their sharpened remains driven into
- the ground like crude stakes.
+At your feet lies a torn, weathered tent, its fabric fraying with age. Nearby, trees have been cut and stripped, their sharpened remains driven into the ground like crude stakes.
 --ROOM 83 END--
 --ROOM 84 START--
 Lumirath Cave
 85,0,0,83
-   A grim sight halts you in your tracks-a pile of human bones, picked clean of
- flesh, littering the trail ahead. A faint, lingering scent of decay hangs in
- the air.
+A grim sight halts you in your tracks-a pile of human bones, picked clean of flesh, littering the trail ahead. A faint, lingering scent of decay hangs in the air.
 --ROOM 84 END--
 --ROOM 85 START--
 Lumirath Cave
 86,84,0,0
-   Every step feels perilous, as if the ground itself conspires against you.
- Doubt gnaws at your resolve, urging you to question whether you should press
- onward.
+Every step feels perilous, as if the ground itself conspires against you. Doubt gnaws at your resolve, urging you to question whether you should press onward.
 --ROOM 85 END--
 --ROOM 86 START--
 Lumirath Cave
 88,85,87,0
-   Pushing through the dense, tangled brush, you emerge into an open space. The
- jungle lies behind you now, its mysteries still clinging to the air like a
- faint whisper.
+Pushing through the dense, tangled brush, you emerge into an open space. The jungle lies behind you now, its mysteries still clinging to the air like a faint whisper.
 --ROOM 86 END--
 --ROOM 87 START--
 Lumirath Cave
 0,0,0,86
-   The surroundings shift, and a sense of familiarity returns. This place feels
- more like the depths of an underground cavern, its dark, enclosing walls
- pressing in with a silent weight.
+The surroundings shift, and a sense of familiarity returns. This place feels more like the depths of an underground cavern, its dark, enclosing walls pressing in with a silent weight.
 --ROOM 87 END--
 --ROOM 88 START--
 Lumirath Cave
 0,86,0,89
-   Before you stands a large silver bowl, tarnished yet regal. Its purpose is
- clear: once a vessel for offerings to a god or deity, it exudes an air of
- reverence and forgotten rituals.
+Before you stands a large silver bowl, tarnished yet regal. Its purpose is clear: once a vessel for offerings to a god or deity, it exudes an air of reverence and forgotten rituals.
 --ROOM 88 END--
 --ROOM 89 START--
 Lumirath Cave
 90,0,88,0
-   The flickering light of torches dances across the walls, casting shifting
- shadows that seem alive. You stand at the entrance to an imposing temple, its
- grandeur tempered by time, or you may retreat into the jungle's enveloping
- darkness.
+The flickering light of torches dances across the walls, casting shifting shadows that seem alive. You stand at the entrance to an imposing temple, its grandeur tempered by time, or you may retreat into the jungle's enveloping darkness.
 --ROOM 89 END--
 --ROOM 90 START--
 Temple of Solace
 91,89,0,0
-   You step into this forbidden sanctuary, untouched by the eyes of outsiders
- for countless years. The air carries a rich bouquet of fermented fruit and
- honey, a fragrance both sweet and heady.
+You step into this forbidden sanctuary, untouched by the eyes of outsiders for countless years. The air carries a rich bouquet of fermented fruit and honey, a fragrance both sweet and heady.
 --ROOM 90 END--
 --ROOM 91 START--
 Temple of Solace
 92,90,0,0
-   Carved deep within the cave, you tread the hollowed halls of this sacred
- place. In the dim light, a Priestess stands before you, her presence serene
- and commanding.
+Carved deep within the cave, you tread the hollowed halls of this sacred place. In the dim light, a Priestess stands before you, her presence serene and commanding.
 --ROOM 91 END--
 --ROOM 92 START--
 Temple of Solace
 0,91,0,93
-   A faint, ethereal haze fills the air. Kneeling before an imposing statue, a
- figure is lost in prayer, their devotion palpable.
+A faint, ethereal haze fills the air. Kneeling before an imposing statue, a figure is lost in prayer, their devotion palpable.
 --ROOM 92 END--
 --ROOM 93 START--
 Temple of Solace
 0,94,92,0
-   Simple beds line the floor, a modest arrangement meant to welcome weary
- visitors seeking a night's rest.
+Simple beds line the floor, a modest arrangement meant to welcome weary visitors seeking a night's rest.
 --ROOM 93 END--
 --ROOM 94 START--
 Temple of Solace
 93,0,0,95
-   This long, narrow hallway is adorned with portraits, each capturing moments
- of triumph and tragedy from this place's storied past.
+This long, narrow hallway is adorned with portraits, each capturing moments of triumph and tragedy from this place's storied past.
 --ROOM 94 END--
 --ROOM 95 START--
 Temple of Solace
 0,0,94,96
-   The flickering light of your lantern dances across the walls, illuminating
- the intricate beauty of this wondrous place of worship.
+The flickering light of your lantern dances across the walls, illuminating the intricate beauty of this wondrous place of worship.
 --ROOM 95 END--
 --ROOM 96 START--
 Temple of Solace
 0,0,95,97
-   You ascend the stairs slowly, finding yourself before a narrow hallway that
- stretches into the unknown, shrouded in mystery.
+You ascend the stairs slowly, finding yourself before a narrow hallway that stretches into the unknown, shrouded in mystery.
 --ROOM 96 END--
 --ROOM 97 START--
 Temple of Solace
 98,0,96,0
-   Soft, haunting music drifts through the air. Large urns, evenly spaced along
- the walls, stand as silent sentinels to this enigmatic chamber.
+Soft, haunting music drifts through the air. Large urns, evenly spaced along the walls, stand as silent sentinels to this enigmatic chamber.
 --ROOM 97 END--
 --ROOM 98 START--
 Temple of Solace
 99,97,0,0
-   A Priest greets you with a warm smile, his hands deftly arranging tools of
- study as he prepares for the day's contemplations.
+A Priest greets you with a warm smile, his hands deftly arranging tools of study as he prepares for the day's contemplations.
 --ROOM 98 END--
 --ROOM 99 START--
 Temple of Solace
 100,98,0,0
-   The mouthwatering aroma of a meal wafts through the air as you stumble into
- a small kitchen. A table laden with ingredients sits beneath a shelf where
- more hang in readiness.
+The mouthwatering aroma of a meal wafts through the air as you stumble into a small kitchen. A table laden with ingredients sits beneath a shelf where more hang in readiness.
 --ROOM 99 END--
 --ROOM 100 START--
 Temple of Solace
 101,99,0,0
-   This cramped dining area is sparsely furnished with a few tables and chairs.
- The oppressive stillness gives it an almost forlorn atmosphere.
+This cramped dining area is sparsely furnished with a few tables and chairs. The oppressive stillness gives it an almost forlorn atmosphere.
 --ROOM 100 END--
 --ROOM 101 START--
 Temple of Solace
 0,100,0,102
-   You step into a chamber steeped in mystery, its air thick with the scent of
- parchment and time. Ancient scrolls lie scattered and undisturbed, whispering
- forgotten secrets to those who dare to listen.
+You step into a chamber steeped in mystery, its air thick with the scent of parchment and time. Ancient scrolls lie scattered and undisturbed, whispering forgotten secrets to those who dare to listen.
 --ROOM 101 END--
 --ROOM 102 START--
 Temple of Solace
 0,0,101,103
-   A serene Priestess greets you warmly, her presence radiating a quiet power.
- You've entered the inner sanctum, where the divine seems to hum softly in the
- air around you.
+A serene Priestess greets you warmly, her presence radiating a quiet power. You've entered the inner sanctum, where the divine seems to hum softly in the air around you.
 --ROOM 102 END--
 --ROOM 103 START--
 Temple of Solace
 111,0,102,104
-   The walls are alive with sacred texts and intricate symbols, their purpose
- clear-to inspire faith and guide a leader destined to shape the future of this
- temple.
+The walls are alive with sacred texts and intricate symbols, their purpose clear-to inspire faith and guide a leader destined to shape the future of this temple.
 --ROOM 103 END--
 --ROOM 104 START--
 Temple of Solace
 0,105,103,0
-   An aged priest stands solemnly before you, clutching a weathered tome. The
- stark emptiness of the room serves as a stark reminder that true devotion
- requires no material adornment.
+An aged priest stands solemnly before you, clutching a weathered tome. The stark emptiness of the room serves as a stark reminder that true devotion requires no material adornment.
 --ROOM 104 END--
 --ROOM 105 START--
 Temple of Solace
 104,106,0,0
-   Venturing deeper into the temple, the light fades as you pass walls cloaked
- in dust and veiled in cobwebs, a tangible silence echoing the abyss that lies
- ahead.
+Venturing deeper into the temple, the light fades as you pass walls cloaked in dust and veiled in cobwebs, a tangible silence echoing the abyss that lies ahead.
 --ROOM 105 END--
 --ROOM 106 START--
 Temple of Solace
 105,107,0,0
-   The corridor gives way to a row of iron-barred cells, their cold metal
- holding the memories of those long forgotten. A shiver creeps up your spine as
- shadows flicker ominously.
+The corridor gives way to a row of iron-barred cells, their cold metal holding the memories of those long forgotten. A shiver creeps up your spine as shadows flicker ominously.
 --ROOM 106 END--
 --ROOM 107 START--
 Temple of Solace
 106,0,108,0
-   You stand before a towering statue of the God of Life, its gaze both
- commanding and protective. It watches over the room, a silent sentinel of
- those who dare to enter.
+You stand before a towering statue of the God of Life, its gaze both commanding and protective. It watches over the room, a silent sentinel of those who dare to enter.
 --ROOM 107 END--
 --ROOM 108 START--
 Temple of Solace
 0,109,0,107
-   This modest chamber is littered with splintered wood, abandoned and decaying
- with time. A faint draft reveals an opening to a hidden backroom, beckoning
- you to explore further.
+This modest chamber is littered with splintered wood, abandoned and decaying with time. A faint draft reveals an opening to a hidden backroom, beckoning you to explore further.
 --ROOM 108 END--
 --ROOM 109 START--
 Temple of Solace
 108,0,110,0
-   The room is a maze of crates stacked high, their contents a mystery sealed
- by time and neglect. The faint scent of musty wood hangs in the air, inviting
- curiosity.
+The room is a maze of crates stacked high, their contents a mystery sealed by time and neglect. The faint scent of musty wood hangs in the air, inviting curiosity.
 --ROOM 109 END--
 --ROOM 110 START--
 Temple of Solace
 0,0,0,109
-   You reach a dead end, the stone walls scarred with claw-like scratche
- evidence of desperate hands carving into unforgiving rock.
+You reach a dead end, the stone walls scarred with claw-like scratche evidence of desperate hands carving into unforgiving rock.
 --ROOM 110 END--
 --ROOM 111 START--
 Temple of Solace
 112,103,0,0
-   A dimly lit study greets you, where an old wooden table groans under the
- weight of aged tomes and scrolls. Flickering candles cast a warm, wavering
- light across the room, evoking a sense of quiet reverence.
+A dimly lit study greets you, where an old wooden table groans under the weight of aged tomes and scrolls. Flickering candles cast a warm, wavering light across the room, evoking a sense of quiet reverence.
 --ROOM 111 END--
 --ROOM 112 START--
 Temple of Solace
 0,111,0,0
-   At the heart of the room, a wooden throne commands attention. Draped banners
- hang from the ceiling, their vibrant colors framing the Head Priest, who
- greets you with a knowing smile that feels both comforting and unsettling.
+At the heart of the room, a wooden throne commands attention. Draped banners hang from the ceiling, their vibrant colors framing the Head Priest, who greets you with a knowing smile that feels both comforting and unsettling.
 --ROOM 112 END--
 --ROOM 113 START--
 The Cemetery
 0,0,32,114
-   You stand at the threshold of the final resting place of the dead, a realm
- steeped in silence and the heavy weight of decay.
+You stand at the threshold of the final resting place of the dead, a realm steeped in silence and the heavy weight of decay.
 --ROOM 113 END--
 --ROOM 114 START--
 The Cemetery
 0,0,113,115
-   The pathway, carved deep into the Earth, invites reverence. You hold your
- breath, not wanting to disturb the serenity of this peaceful place.
+The pathway, carved deep into the Earth, invites reverence. You hold your breath, not wanting to disturb the serenity of this peaceful place.
 --ROOM 114 END--
 --ROOM 115 START--
 The Cemetery
 0,116,114,127
-   Blossoming trees lend a rare warmth to this otherwise forgotten corner of
- the world, as though nature refuses to let it fade entirely.
+Blossoming trees lend a rare warmth to this otherwise forgotten corner of the world, as though nature refuses to let it fade entirely.
 --ROOM 115 END--
 --ROOM 116 START--
 The Cemetery
 115,117,0,0
-   Every part of this place has been lovingly tended, a poignant reminder that
- even in obscurity, the dead are not abandoned.
+Every part of this place has been lovingly tended, a poignant reminder that even in obscurity, the dead are not abandoned.
 --ROOM 116 END--
 --ROOM 117 START--
 The Cemetery
 116,0,118,0
-   You cross a small bridge spanning a long-dried stream, its rocky bed a
- silent echo of what once flowed here.
+You cross a small bridge spanning a long-dried stream, its rocky bed a silent echo of what once flowed here.
 --ROOM 117 END--
 --ROOM 118 START--
 The Cemetery
 0,119,0,117
-   Neatly arranged rows of gravestones mark the land, each one a solemn
- reminder of the inevitable path we all must take.
+Neatly arranged rows of gravestones mark the land, each one a solemn reminder of the inevitable path we all must take.
 --ROOM 118 END--
 --ROOM 119 START--
 The Cemetery
 118,0,120,0
-   The profound silence enveloping this place sends an icy chill down your
- spine, as if the stillness itself is alive.
+The profound silence enveloping this place sends an icy chill down your spine, as if the stillness itself is alive.
 --ROOM 119 END--
 --ROOM 120 START--
 The Cemetery
 0,121,0,119
-   As you meander along the path, your gaze begins to linger on the
- gravestones, each one whispering a story of a life once lived.
+As you meander along the path, your gaze begins to linger on the gravestones, each one whispering a story of a life once lived.
 --ROOM 120 END--
 --ROOM 121 START--
 The Cemetery
 120,122,0,0
-   A young woman, dressed in somber black, stands in quiet contemplation,
- paying her respects to a loved one.
+A young woman, dressed in somber black, stands in quiet contemplation, paying her respects to a loved one.
 --ROOM 121 END--
 --ROOM 122 START--
 The Cemetery
 121,125,0,123
-   An expanse of headstones stretches across the land, and a serene calm
- blankets this sacred ground.
+An expanse of headstones stretches across the land, and a serene calm blankets this sacred ground.
 --ROOM 122 END--
 --ROOM 123 START--
 The Cemetery
 0,124,122,0
-   With each cautious step along the path, you feel an invisible chill wrapping
- itself around you, urging you to tread carefully.
+With each cautious step along the path, you feel an invisible chill wrapping itself around you, urging you to tread carefully.
 --ROOM 123 END--
 --ROOM 124 START--
 The Cemetery
 123,126,125,0
-   A lone statue rises before you, its presence strangely out of place yet
- commanding an undeniable gravitas.
+A lone statue rises before you, its presence strangely out of place yet commanding an undeniable gravitas.
 --ROOM 124 END--
 --ROOM 125 START--
 The Cemetery
 122,0,0,124
-   You pause, startled, as the warm voice of a monk calls out to you, breaking
- the stillness with unexpected kindness.
+You pause, startled, as the warm voice of a monk calls out to you, breaking the stillness with unexpected kindness.
 --ROOM 125 END--
 --ROOM 126 START--
 The Cemetery
 124,0,0,0
-   Before you stands nothing but a solitary apple tree, its silent presence a
- stark symbol of the fate that awaits us all.
+Before you stands nothing but a solitary apple tree, its silent presence a stark symbol of the fate that awaits us all.
 --ROOM 126 END--
 --ROOM 127 START--
 The Cemetery
 139,128,115,170
-   All seems calm for the moment, yet an unsettling feeling creeps over you-a
- sensation that unseen eyes are fixed upon you.
+All seems calm for the moment, yet an unsettling feeling creeps over you-a sensation that unseen eyes are fixed upon you.
 --ROOM 127 END--
 --ROOM 128 START--
 The Cemetery
 127,129,0,0
-   The silence around you is broken by the distant toll of a bell. In the
- distance, a funeral service unfolds, shrouded in solemnity.
+The silence around you is broken by the distant toll of a bell. In the distance, a funeral service unfolds, shrouded in solemnity.
 --ROOM 128 END--
 --ROOM 129 START--
 The Cemetery
 128,0,0,130
-   The dead are arranged in orderly rows, yet their names, once etched in
- stone, have faded into oblivion.
+The dead are arranged in orderly rows, yet their names, once etched in stone, have faded into oblivion.
 --ROOM 129 END--
 --ROOM 130 START--
 The Cemetery
 0,131,129,0
-   The world around you seems to blur and dissolve, as if reality itself is
- slipping through your grasp.
+The world around you seems to blur and dissolve, as if reality itself is slipping through your grasp.
 --ROOM 130 END--
 --ROOM 131 START--
 The Cemetery
 130,0,0,132
-   A thin veil of mist creeps in, curling around you as the oppressive darkness
- of the unknown begins to take hold.
+A thin veil of mist creeps in, curling around you as the oppressive darkness of the unknown begins to take hold.
 --ROOM 131 END--
 --ROOM 132 START--
 The Cemetery
 0,133,131,0
-    An ancient willow tree looms before you, its gnarled branches forming a
- solemn threshold between the realms of the living and the dead.
+An ancient willow tree looms before you, its gnarled branches forming a solemn threshold between the realms of the living and the dead.
 --ROOM 132 END--
 --ROOM 133 START--
 The Cemetery
 132,134,0,0
-   The ground quakes beneath your feet, sending shivers through your body as
- the earth threatens to give way beneath you.
+The ground quakes beneath your feet, sending shivers through your body as the earth threatens to give way beneath you.
 --ROOM 133 END--
 --ROOM 134 START--
 The Cemetery
 133,137,135,0
-   Tendrils of smoke rise from the cracked ground, and then a skeletal hand
- bursts forth, clawing desperately to drag you into the abyss.
+Tendrils of smoke rise from the cracked ground, and then a skeletal hand bursts forth, clawing desperately to drag you into the abyss.
 --ROOM 134 END--
 --ROOM 135 START--
 The Cemetery
 0,136,0,134
-   The earth trembles underfoot, and from the swirling mist ahead, a shadowy
- form begins to stir and move toward you.
+The earth trembles underfoot, and from the swirling mist ahead, a shadowy form begins to stir and move toward you.
 --ROOM 135 END--
 --ROOM 136 START--
 The Cemetery
 135,138,0,137
-   From the depths of darkness, incoherent whispers rise, circling you like
- phantoms-an eerie reminder that you are not alone.
+From the depths of darkness, incoherent whispers rise, circling you like phantoms-an eerie reminder that you are not alone.
 --ROOM 136 END--
 --ROOM 137 START--
 The Cemetery
 134,0,136,0
-   You reach a dead end where the ceiling has collapsed, leaving a pile of
- rubble that seals this part of the cave in eternal stillness.
+You reach a dead end where the ceiling has collapsed, leaving a pile of rubble that seals this part of the cave in eternal stillness.
 --ROOM 137 END--
 --ROOM 138 START--
 The Cemetery
 136,0,0,0
-   Before you stands a broken bridge, its remains vanishing into the endless
- darkness of the unknown.
+Before you stands a broken bridge, its remains vanishing into the endless darkness of the unknown.
 --ROOM 138 END--
 --ROOM 139 START--
 The Cemetery
 140,127,0,0
-   A desolate world stretches before you, its ruin palpable. Yet amidst the
- devastation, the dead rest undisturbed in solemn peace.
+A desolate world stretches before you, its ruin palpable. Yet amidst the devastation, the dead rest undisturbed in solemn peace.
 --ROOM 139 END--
 --ROOM 140 START--
 The Cemetery
 0,139,0,167
-   A narrow trail winds its way through the earth, etched by time. The graves
- of the fallen stand as silent sentinels to your journey.
+A narrow trail winds its way through the earth, etched by time. The graves of the fallen stand as silent sentinels to your journey.
 --ROOM 140 END--
 --ROOM 141 START--
 The Cemetery
 142,0,143,0
-   From the distance, a haunting howl rises, chilling and unrelenting, as
- though something unseen is calling out to you.
+From the distance, a haunting howl rises, chilling and unrelenting, as though something unseen is calling out to you.
 --ROOM 141 END--
 --ROOM 142 START--
 The Cemetery
 0,141,0,0
-   Before you lies an open grave, its dark maw gaping in silent invitation.
+Before you lies an open grave, its dark maw gaping in silent invitation.
 --ROOM 142 END--
 --ROOM 143 START--
 The Cemetery
 0,144,0,141
-   An eerie silence blankets the area. Perched atop a gravestone, an owl
- watches you, its gaze unblinking and knowing.
+An eerie silence blankets the area. Perched atop a gravestone, an owl watches you, its gaze unblinking and knowing.
 --ROOM 143 END--
 --ROOM 144 START--
 The Cemetery
 143,145,0,0
-   The skeletal remains of a forsaken soul lie crumpled beside a disturbed
- gravesite, a cautionary tale whispered by the earth itself.
+The skeletal remains of a forsaken soul lie crumpled beside a disturbed gravesite, a cautionary tale whispered by the earth itself.
 --ROOM 144 END--
 --ROOM 145 START--
 The Cemetery
 144,0,146,0
-   A broken shovel leans abandoned on the side of the path, its jagged edge
- hinting at deliberate sabotage.
+A broken shovel leans abandoned on the side of the path, its jagged edge hinting at deliberate sabotage.
 --ROOM 145 END--
 --ROOM 146 START--
 The Cemetery
 0,0,147,145
-   These graves must belong to people of great importance; the signs of
- activity around them suggest a story left untold.
+These graves must belong to people of great importance; the signs of activity around them suggest a story left untold.
 --ROOM 146 END--
 --ROOM 147 START--
 The Cemetery
 148,0,0,146
-   A foul stench hangs heavy in the air. An old woman sways nearby, clutching
- burning incense in a desperate attempt to ward off malevolent spirits.
+A foul stench hangs heavy in the air. An old woman sways nearby, clutching burning incense in a desperate attempt to ward off malevolent spirits.
 --ROOM 147 END--
 --ROOM 148 START--
 The Cemetery
 149,147,0,0
-   Every step feels like a gamble as you wander through this mysterious place,
- curiosity pulling you onward.
+Every step feels like a gamble as you wander through this mysterious place, curiosity pulling you onward.
 --ROOM 148 END--
 --ROOM 149 START--
 The Cemetery
 152,148,0,150
-   Your eyes catch a poignant sight-a single red flower and a toy rest atop a
- child's grave, a bittersweet reminder of innocence lost.
+Your eyes catch a poignant sight-a single red flower and a toy rest atop a child's grave, a bittersweet reminder of innocence lost.
 --ROOM 149 END--
 --ROOM 150 START--
 The Cemetery
 151,0,149,0
-   For a fleeting moment, solace washes over you. Here, the dead seem to rest
- in undisturbed peace.
+For a fleeting moment, solace washes over you. Here, the dead seem to rest in undisturbed peace.
 --ROOM 150 END--
 --ROOM 151 START--
 The Cemetery
 0,150,0,0
-   You freeze in place. Before you kneels a cloaked figure, motionless, its
- attention fixed on a lone grave.
+You freeze in place. Before you kneels a cloaked figure, motionless, its attention fixed on a lone grave.
 --ROOM 151 END--
 --ROOM 152 START--
 The Cemetery
 153,149,0,0
-   The wind howls with renewed vigor as cracks begin to spider across the
- ground, threatening to plunge all into an abyss of the unknown.
+The wind howls with renewed vigor as cracks begin to spider across the ground, threatening to plunge all into an abyss of the unknown.
 --ROOM 152 END--
 --ROOM 153 START--
 The Cemetery
 0,152,0,154
-   A shiver crawls up your spine. In this realm of peace and death, you can't
- shake the feeling that unseen eyes are watching.
+A shiver crawls up your spine. In this realm of peace and death, you can't shake the feeling that unseen eyes are watching.
 --ROOM 153 END--
 --ROOM 154 START--
 The Cemetery
 155,0,153,0
-   Small orbs of light flicker into view, dancing whimsically against the
- eternal darkness, their movement both mesmerizing and otherworldly.
+Small orbs of light flicker into view, dancing whimsically against the eternal darkness, their movement both mesmerizing and otherworldly.
 --ROOM 154 END--
 --ROOM 155 START--
 The Cemetery
 0,154,0,156
-   The rugged rock walls of this underground cemetery loom around you, a stark
- reminder of the tomb-like silence that enfolds this place.
+The rugged rock walls of this underground cemetery loom around you, a stark reminder of the tomb-like silence that enfolds this place.
 --ROOM 155 END--
 --ROOM 156 START--
 The Cemetery
 0,0,0,157
-   The cold radiating from the stone walls is so biting, you can see your
- breath misting in the frigid air.
+The cold radiating from the stone walls is so biting, you can see your breath misting in the frigid air.
 --ROOM 156 END--
 --ROOM 157 START--
 The Cemetery
 0,158,158,159
-   An unsettling quiet pervades the scene, broken only by the faint aroma of
- something cooking over a distant fire.
+An unsettling quiet pervades the scene, broken only by the faint aroma of something cooking over a distant fire.
 --ROOM 157 END--
 --ROOM 158 START--
 The Cemetery
 157,0,155,0
-   A makeshift wooden shack cobbled together from scavenged materials stands
- before you. A small fire crackles nearby, roasting what appears to be rabbit
- meat. A weary, dirt-streaked caretaker greets you with a nod.
+A makeshift wooden shack cobbled together from scavenged materials stands before you. A small fire crackles nearby, roasting what appears to be rabbit meat. A weary, dirt-streaked caretaker greets you with a nod.
 --ROOM 158 END--
 --ROOM 159 START--
 The Cemetery
 0,0,157,160
-   The ground betrays the chaos of a world lost, exposing fragments of bone and
- stone amid the shifting dirt.
+The ground betrays the chaos of a world lost, exposing fragments of bone and stone amid the shifting dirt.
 --ROOM 159 END--
 --ROOM 160 START--
 The Cemetery
 0,161,159,0
-   You roam through the desolate expanse, a haunting stillness pressing down on
- you. Death lingers in every shadow, an omnipresent reminder of life's end.
+You roam through the desolate expanse, a haunting stillness pressing down on you. Death lingers in every shadow, an omnipresent reminder of life's end.
 --ROOM 160 END--
 --ROOM 161 START--
 The Cemetery
 160,162,0,0
-   Beneath the surface of the earth lies a forgotten world, lost to the living.
- Yet, despite its eerie wonder, you feel only unease and dread.
+Beneath the surface of the earth lies a forgotten world, lost to the living. Yet, despite its eerie wonder, you feel only unease and dread.
 --ROOM 161 END--
 --ROOM 162 START--
 The Cemetery
 161,165,0,163
-   A narrow opening in the forest lies ahead. The oppressive silence gnaws at
- your courage, leaving you dreading what might await.
+A narrow opening in the forest lies ahead. The oppressive silence gnaws at your courage, leaving you dreading what might await.
 --ROOM 162 END--
 --ROOM 163 START--
 The Cemetery
 0,0,162,164
-   A concealed path winds through dense brush and jagged rock. With each
- precarious step, a crushing weight seems to bear down on your body, testing
- your resolve.
+A concealed path winds through dense brush and jagged rock. With each precarious step, a crushing weight seems to bear down on your body, testing your resolve.
 --ROOM 163 END--
 --ROOM 164 START--
 The Cemetery
 0,0,163,0
-   The skeletal remains of a woman lie crumpled on the ground. Her decayed
- hands clutch stolen grave goods-jewelry pilfered from the dead-an unsettling
- testament to her final acts.
+The skeletal remains of a woman lie crumpled on the ground. Her decayed hands clutch stolen grave goods-jewelry pilfered from the dead-an unsettling testament to her final acts.
 --ROOM 164 END--
 --ROOM 165 START--
 The Cemetery
 162,166,0,0
-   Disturbed graves litter the area, their contents scattered and desecrated.
- The anguished souls of the departed will never find peace here.
+Disturbed graves litter the area, their contents scattered and desecrated. The anguished souls of the departed will never find peace here.
 --ROOM 165 END--
 --ROOM 166 START--
 The Cemetery
 165,168,167,0
-   You wander aimlessly, the endless desolation offering no reprieve or
- direction.
+You wander aimlessly, the endless desolation offering no reprieve or direction.
 --ROOM 166 END--
 --ROOM 167 START--
 The Cemetery
 0,0,140,166
-   A sudden contrast greets you-a delicate aroma of perfume and freshly laid
- flowers fills the air, a fragile beauty amidst the decay.
+A sudden contrast greets you-a delicate aroma of perfume and freshly laid flowers fills the air, a fragile beauty amidst the decay.
 --ROOM 167 END--
 --ROOM 168 START--
 The Cemetery
 166,169,0,171
-   The stark inevitability of death surrounds you, a constant and unrelenting
- reminder of what lies ahead for all.
+The stark inevitability of death surrounds you, a constant and unrelenting reminder of what lies ahead for all.
 --ROOM 168 END--
 --ROOM 169 START--
 The Cemetery
 168,0,170,0
-   A meandering path twists through the undergrowth. As you tread cautiously,
- you wonder where this disquieting journey will lead you next.
+A meandering path twists through the undergrowth. As you tread cautiously, you wonder where this disquieting journey will lead you next.
 --ROOM 169 END--
 --ROOM 170 START--
 The Cemetery
 0,0,127,169
-   Freshly turned earth catches your attention-a newly dug grave, its presence
- ominous and unexplained.
+Freshly turned earth catches your attention-a newly dug grave, its presence ominous and unexplained.
 --ROOM 170 END--
 --ROOM 171 START--
 The Cemetery
 0,0,168,172
-   An ancient, overgrown path stretches before you, forgotten by time. Whatever
- lies within this forsaken realm remains shrouded in uncertainty and fear.
+An ancient, overgrown path stretches before you, forgotten by time. Whatever lies within this forsaken realm remains shrouded in uncertainty and fear.
 --ROOM 171 END--
 --ROOM 172 START--
 The Cemetery
 0,173,171,0
-   You stand at the threshold of an old mausoleum. Its imposing metal doors
- groan open with a deliberate slowness, as though someone-or something-waits
- inside.
+You stand at the threshold of an old mausoleum. Its imposing metal doors groan open with a deliberate slowness, as though someone-or something-waits inside.
 --ROOM 172 END--
 --ROOM 173 START--
 The Cemetery
 172,174,0,0
-   Massive stone slabs mark the final resting places of the dead. Flickering
- torches cast eerie light upon the cold walls, their flames stubbornly
- resisting the darkness.
+Massive stone slabs mark the final resting places of the dead. Flickering torches cast eerie light upon the cold walls, their flames stubbornly resisting the darkness.
 --ROOM 173 END--
 --ROOM 174 START--
 The Cemetery
 173,175,0,0
-   The room is lined with crude wooden tables, stained with the remnants of
- grim experiments. Dissected corpses lie abandoned, while a faint, otherworldly
- chant echoes in an unknown tongue, summoning restless spirits.
+The room is lined with crude wooden tables, stained with the remnants of grim experiments. Dissected corpses lie abandoned, while a faint, otherworldly chant echoes in an unknown tongue, summoning restless spirits.
 --ROOM 174 END--
 --ROOM 175 START--
 The Cemetery
 174,0,0,0
-   Before you stands the Necromancer, cloaked in black and poised at an ancient
- altar. Arms raised to the heavens, they cry out in a dark ritual, as though
- calling the dead to rise once more.
+Before you stands the Necromancer, cloaked in black and poised at an ancient altar. Arms raised to the heavens, they cry out in a dark ritual, as though calling the dead to rise once more.
 --ROOM 175 END--
 --ROOM 176 START--
 The King's Castle
 177,46,0,0
-   You stand before the grand entrance of the castle, its towering gates
- weathered and cracked with age. The air carries a heavy stillness, as if the
- stones themselves whisper tales of forgotten glories.
+You stand before the grand entrance of the castle, its towering gates weathered and cracked with age. The air carries a heavy stillness, as if the stones themselves whisper tales of forgotten glories.
 --ROOM 176 END--
 --ROOM 177 START--
 The King's Castle
 178,176,0,0
-   Portraits of long-dead nobles hang crookedly on the walls, their faces
- obscured by grime. The air reeks of decay, a stench that clings to your
- senses.
+Portraits of long-dead nobles hang crookedly on the walls, their faces obscured by grime. The air reeks of decay, a stench that clings to your senses.
 --ROOM 177 END--
 --ROOM 178 START--
 The King's Castle
 179,177,180,198
-   A stoic Knight of the King's Guard greets you, his polished armor gleaming
- faintly despite the dim light. He stands unwavering at his post, his presence
- both reassuring and formidable.
+A stoic Knight of the King's Guard greets you, his polished armor gleaming faintly despite the dim light. He stands unwavering at his post, his presence both reassuring and formidable.
 --ROOM 178 END--
 --ROOM 179 START--
 The King's Castle
 0,178,0,0
-   A grand stone fountain dominates the courtyard, its crystal-clear waters
- cascading gracefully. The soothing sound of the flowing water seems to wash
- away the weight of your journey.
+A grand stone fountain dominates the courtyard, its crystal-clear waters cascading gracefully. The soothing sound of the flowing water seems to wash away the weight of your journey.
 --ROOM 179 END--
 --ROOM 180 START--
 The King's Castle
 181,0,0,178
-   Tables laden with sumptuous feasts and goblets of wine fill the room.
- Laughter and chatter echo as nobles in fine attire revel in celebration.
+Tables laden with sumptuous feasts and goblets of wine fill the room. Laughter and chatter echo as nobles in fine attire revel in celebration.
 --ROOM 180 END--
 --ROOM 181 START--
 The King's Castle
 182,180,0,0
-   A Bard meanders through the hall, his lute strumming a lively tune. His
- voice rises in a ballad of heroes and distant lands, captivating all who hear.
+A Bard meanders through the hall, his lute strumming a lively tune. His voice rises in a ballad of heroes and distant lands, captivating all who hear.
 --ROOM 181 END--
 --ROOM 182 START--
 The King's Castle
 183,181,0,0
-   The faint aroma of perfume lingers in the air as guests cast relieved
- glances your way, their eyes filled with hope amidst the opulence of the
- castle.
+The faint aroma of perfume lingers in the air as guests cast relieved glances your way, their eyes filled with hope amidst the opulence of the castle.
 --ROOM 182 END--
 --ROOM 183 START--
 The King's Castle
 184,182,0,0
-   Every step you take echoes through the castle's labyrinthine corridors. The
- layout feels disorienting, as if the very walls conspire to confuse you.
+Every step you take echoes through the castle's labyrinthine corridors. The layout feels disorienting, as if the very walls conspire to confuse you.
 --ROOM 183 END--
 --ROOM 184 START--
 The King's Castle
 185,183,0,0
-   The walls are adorned with the royal family's crest, surrounded by
- tapestries and artifacts recounting their storied reign.
+The walls are adorned with the royal family's crest, surrounded by tapestries and artifacts recounting their storied reign.
 --ROOM 184 END--
 --ROOM 185 START--
 The King's Castle
 199,184,0,186
-   Music drifts through the air, blending with the soft hum of conversation as
- guests mingle in the warmly lit chamber.
+Music drifts through the air, blending with the soft hum of conversation as guests mingle in the warmly lit chamber.
 --ROOM 185 END--
 --ROOM 186 START--
 The King's Castle
 0,0,185,187
-   You enter the throne room, its vaulted ceilings drawing your gaze upward.
- The King sits upon a grand throne, flanked by a circle of advisors murmuring
- in low tones.
+You enter the throne room, its vaulted ceilings drawing your gaze upward. The King sits upon a grand throne, flanked by a circle of advisors murmuring in low tones.
 --ROOM 186 END--
 --ROOM 187 START--
 The King's Castle
 188,194,186,0
-   Benches line the walls of this chamber, where weary soldiers rest, their
- armor dented and cloaks muddied from recent battles.
+Benches line the walls of this chamber, where weary soldiers rest, their armor dented and cloaks muddied from recent battles.
 --ROOM 187 END--
 --ROOM 188 START--
 The King's Castle
 0,187,0,189
-   Hushed voices fill the room as people exchange nervous glances, their
- whispers tinged with fear as they speak of the growing darkness beyond the
- castle walls.
+Hushed voices fill the room as people exchange nervous glances, their whispers tinged with fear as they speak of the growing darkness beyond the castle walls.
 --ROOM 188 END--
 --ROOM 189 START--
 The King's Castle
 0,0,188,190
-   Twisting corridors and shadowy alcoves create a maze of mystery. Many doors
- remain sealed, their secrets locked away.
+Twisting corridors and shadowy alcoves create a maze of mystery. Many doors remain sealed, their secrets locked away.
 --ROOM 189 END--
 --ROOM 190 START--
 The King's Castle
 0,191,189,0
-   A group of nobles huddles together, their tense whispers carrying a tone of
- dissatisfaction. They pause their conversation as you approach, eyeing you
- warily.
+A group of nobles huddles together, their tense whispers carrying a tone of dissatisfaction. They pause their conversation as you approach, eyeing you warily.
 --ROOM 190 END--
 --ROOM 191 START--
 The King's Castle
 190,192,0,0
-   Gentle music follows you as you wander through the castle's opulent halls,
- each one more lavishly decorated than the last.
+Gentle music follows you as you wander through the castle's opulent halls, each one more lavishly decorated than the last.
 --ROOM 191 END--
 --ROOM 192 START--
 The King's Castle
 191,0,193,0
-   You stand before an empty ballroom, its grandeur overwhelming. Walls
- encrusted with gold and jewels shimmer faintly in the dim light, a silent
- testament to the kingdom's wealth.
+You stand before an empty ballroom, its grandeur overwhelming. Walls encrusted with gold and jewels shimmer faintly in the dim light, a silent testament to the kingdom's wealth.
 --ROOM 192 END--
 --ROOM 193 START--
 The King's Castle
 0,0,194,192
-   This section of the castle is eerily quiet. The silence presses against you
- as you tread carefully, wondering what challenges lie ahead.
+This section of the castle is eerily quiet. The silence presses against you as you tread carefully, wondering what challenges lie ahead.
 --ROOM 193 END--
 --ROOM 194 START--
 The King's Castle
 187,195,0,193
-   Candlelight flickers in iron sconces, casting dancing shadows along the
- stone walls. For a moment, you feel an odd sense of belonging, as though the
- castle itself embraces your presence.
+Candlelight flickers in iron sconces, casting dancing shadows along the stone walls. For a moment, you feel an odd sense of belonging, as though the castle itself embraces your presence.
 --ROOM 194 END--
 --ROOM 195 START--
 The King's Castle
 194,196,0,0
-   The wide hallway is lined with portraits of the royal family. Each painting
- depicts a chapter of their legacy, from triumph to tragedy.
+The wide hallway is lined with portraits of the royal family. Each painting depicts a chapter of their legacy, from triumph to tragedy.
 --ROOM 195 END--
 --ROOM 196 START--
 The King's Castle
 195,197,0,0
-   As you navigate the infernal hall, you encounter Princess Feyheart standing
- alone. Her gaze meets yours, and an air of quiet strength surrounds her.
+As you navigate the infernal hall, you encounter Princess Feyheart standing alone. Her gaze meets yours, and an air of quiet strength surrounds her.
 --ROOM 196 END--
 --ROOM 197 START--
 The King's Castle
 196,198,0,0
-   The castle's sprawling halls stretch endlessly before you, each step filled
- with anticipation for the path that lies ahead.
+The castle's sprawling halls stretch endlessly before you, each step filled with anticipation for the path that lies ahead.
 --ROOM 197 END--
 --ROOM 198 START--
 The King's Castle
 197,0,178,0
-   A Priest intercepts you with a solemn expression. His worried eyes hint at
- unspoken fears as he offers a blessing for your journey.
+A Priest intercepts you with a solemn expression. His worried eyes hint at unspoken fears as he offers a blessing for your journey.
 --ROOM 198 END--
 --ROOM 199 START--
 The King's Castle
 200,185,0,0
-   A cold breeze brushes past, and the candles flicker wildly. For an instant,
- you feel the icy grip of something unseen against your arm, sending a shiver
- down your spine.
+A cold breeze brushes past, and the candles flicker wildly. For an instant, you feel the icy grip of something unseen against your arm, sending a shiver down your spine.
 --ROOM 199 END--
 --ROOM 200 START--
 The King's Castle
 0,199,201,206
-   The floor trembles beneath your feet, and a faint tapping sound echoes from
- the distance. Each rhythmic beat feels like a harbinger of something ominous.
+The floor trembles beneath your feet, and a faint tapping sound echoes from the distance. Each rhythmic beat feels like a harbinger of something ominous.
 --ROOM 200 END--
 --ROOM 201 START--
 The King's Castle
 0,202,0,200
-   You find yourself in a narrow passageway within the castle, the darkness
- pressing in from all sides as you navigate its confines.
+You find yourself in a narrow passageway within the castle, the darkness pressing in from all sides as you navigate its confines.
 --ROOM 201 END--
 --ROOM 202 START--
 The King's Castle
 201,203,0,0
-   The air grows thick and oppressive as you ascend a spiral staircase,
- emerging into a shadowy, foreboding chamber.
+The air grows thick and oppressive as you ascend a spiral staircase, emerging into a shadowy, foreboding chamber.
 --ROOM 202 END--
 --ROOM 203 START--
 The King's Castle
 202,204,0,0
-   The scent of mint permeates the air, and before you stands a weary old
- figure whose presence exudes a sense of ancient wisdom.
+The scent of mint permeates the air, and before you stands a weary old figure whose presence exudes a sense of ancient wisdom.
 --ROOM 203 END--
 --ROOM 204 START--
 The King's Castle
 203,0,205,0
-   In this secluded chamber, the Royal Wizard himself stands before you, a
- master of arcane magic engrossed in his esoteric studies.
+In this secluded chamber, the Royal Wizard himself stands before you, a master of arcane magic engrossed in his esoteric studies.
 --ROOM 204 END--
 --ROOM 205 START--
 The King's Castle
 0,0,0,204
-   Tables laden with ancient tomes stretch across the room, their pages
- brimming with knowledge hidden from the common world.
+Tables laden with ancient tomes stretch across the room, their pages brimming with knowledge hidden from the common world.
 --ROOM 205 END--
 --ROOM 206 START--
 The King's Castle
 207,0,200,0
-   Before you, a section of the wall slides away with a soft grating sound,
- revealing a concealed passageway shrouded in mystery.
+Before you, a section of the wall slides away with a soft grating sound, revealing a concealed passageway shrouded in mystery.
 --ROOM 206 END--
 --ROOM 207 START--
 The King's Castle
 208,206,0,215
-   You creep silently through a damp, cold corridor, its stone walls bearing
- the weight of countless secrets.
+You creep silently through a damp, cold corridor, its stone walls bearing the weight of countless secrets.
 --ROOM 207 END--
 --ROOM 208 START--
 The King's Castle
 0,207,209,0
-   A narrow staircase twists downward, leading you to a place you sense you
- will never forget.
+A narrow staircase twists downward, leading you to a place you sense you will never forget.
 --ROOM 208 END--
 --ROOM 209 START--
 The King's Castle
 210,0,0,208
-   The flickering light of your lantern casts dancing shadows across the walls,
- creating fleeting, eerie shapes.
+The flickering light of your lantern casts dancing shadows across the walls, creating fleeting, eerie shapes.
 --ROOM 209 END--
 --ROOM 210 START--
 The King's Castle
 211,209,0,0
-   Ascending the staircase, you find yourself in a room that stirs unease, its
- darkened corners heavy with forgotten memories.
+Ascending the staircase, you find yourself in a room that stirs unease, its darkened corners heavy with forgotten memories.
 --ROOM 210 END--
 --ROOM 211 START--
 The King's Castle
 0,210,212,0
-   The soot-streaked stone walls close in around you, and as you round a
- corner, a small, ancient fireplace comes into view.
+The soot-streaked stone walls close in around you, and as you round a corner, a small, ancient fireplace comes into view.
 --ROOM 211 END--
 --ROOM 212 START--
 The King's Castle
 0,0,213,211
-   The howling wind beyond the stone walls sends ghostly echoes through the
- space, chilling you to the bone.
+The howling wind beyond the stone walls sends ghostly echoes through the space, chilling you to the bone.
 --ROOM 212 END--
 --ROOM 213 START--
 The King's Castle
 214,0,0,212
-   As you approach a long staircase, you notice a wooden beam precariously
- bowing under the immense weight of stone and earth above.
+As you approach a long staircase, you notice a wooden beam precariously bowing under the immense weight of stone and earth above.
 --ROOM 213 END--
 --ROOM 214 START--
 The King's Castle
 222,213,0,0
-   Standing at the base of an ancient watchtower, you wonder what secrets await
- at its summit.
+Standing at the base of an ancient watchtower, you wonder what secrets await at its summit.
 --ROOM 214 END--
 --ROOM 215 START--
 The King's Castle
 0,0,207,216
-   With each step, the world around you seems to shift and change, drawing you
- inexorably toward the labyrinth.
+With each step, the world around you seems to shift and change, drawing you inexorably toward the labyrinth.
 --ROOM 215 END--
 --ROOM 216 START--
 The King's Castle
 0,0,215,217
-   The stone pathway abruptly transforms beneath your feet, depositing you in a
- place alien and unfamiliar.
+The stone pathway abruptly transforms beneath your feet, depositing you in a place alien and unfamiliar.
 --ROOM 216 END--
 --ROOM 217 START--
 The King's Castle
 218,0,216,0
-   Two towering pillars rise on either side of you, their craftsmanship a
- testament to the hands of ancient keepers.
+Two towering pillars rise on either side of you, their craftsmanship a testament to the hands of ancient keepers.
 --ROOM 217 END--
 --ROOM 218 START--
 The King's Castle
 219,217,0,0
-   A long staircase descends into the depths, vanishing into the inky void of
- an unfathomable abyss.
+A long staircase descends into the depths, vanishing into the inky void of an unfathomable abyss.
 --ROOM 218 END--
 --ROOM 219 START--
 The King's Castle
 0,218,0,220
-   At the base of the stairs, a dense haze obscures the distance, its swirling
- depths concealing what lies beyond.
+At the base of the stairs, a dense haze obscures the distance, its swirling depths concealing what lies beyond.
 --ROOM 219 END--
 --ROOM 220 START--
 The King's Castle
 0,0,219,221
-   From the enveloping darkness, bloodcurdling screams reverberate off the
- stone walls, their source eluding your senses.
+From the enveloping darkness, bloodcurdling screams reverberate off the stone walls, their source eluding your senses.
 --ROOM 220 END--
 --ROOM 221 START--
 The King's Castle
 0,0,220,254
-   You stand before the grand entrance of the labyrinth, an oppressive
- sensation of unseen eyes upon you filling you with unease.
+You stand before the grand entrance of the labyrinth, an oppressive sensation of unseen eyes upon you filling you with unease.
 --ROOM 221 END--
 --ROOM 222 START--
 The Tower
 223,214,0,0
-   You climb a long spiral staircase, each step creaking underfoot on the old
- wooden floor. The boards groan ominously as if they might give way at any
- moment.
+You climb a long spiral staircase, each step creaking underfoot on the old wooden floor. The boards groan ominously as if they might give way at any moment.
 --ROOM 222 END--
 --ROOM 223 START--
 The Tower
 0,222,224,0
-   The wind howls past you, a relentless, chilling presence. The only
- illumination comes from your lantern, its flickering light barely piercing the
- surrounding gloom.
+The wind howls past you, a relentless, chilling presence. The only illumination comes from your lantern, its flickering light barely piercing the surrounding gloom.
 --ROOM 223 END--
 --ROOM 224 START--
 The Tower
 242,0,225,223
-   The walls are blanketed in a fine layer of dust, their surfaces dulled by
- age. Cobwebs drape from the ceiling, swaying gently in unseen drafts.
+The walls are blanketed in a fine layer of dust, their surfaces dulled by age. Cobwebs drape from the ceiling, swaying gently in unseen drafts.
 --ROOM 224 END--
 --ROOM 225 START--
 The Tower
 0,0,226,224
-   You pass by a large, open archway that offers a breathtaking view of the
- forest encircling the village below. The air carries the faint scent of pine
- and damp earth.
+You pass by a large, open archway that offers a breathtaking view of the forest encircling the village below. The air carries the faint scent of pine and damp earth.
 --ROOM 225 END--
 --ROOM 226 START--
 The Tower
 239,0,227,225
-   The ground shudders beneath your feet, a subtle but ominous vibration.
- Distant thunder rumbles as a storm slowly gathers on the horizon.
+The ground shudders beneath your feet, a subtle but ominous vibration. Distant thunder rumbles as a storm slowly gathers on the horizon.
 --ROOM 226 END--
 --ROOM 227 START--
 The Tower
 0,0,228,226
-   Brilliant flashes of lightning split the sky, their fleeting brilliance
- casting eerie, fleeting shadows across the tower. For a moment, the lifeless
- stone seems almost alive.
+Brilliant flashes of lightning split the sky, their fleeting brilliance casting eerie, fleeting shadows across the tower. For a moment, the lifeless stone seems almost alive.
 --ROOM 227 END--
 --ROOM 228 START--
 The Tower
 229,0,0,227
-   As you wander through the area, you spot a lone Guard standing at his post.
- His gaze is fixed outward, scanning the landscape with a practiced vigilance.
+As you wander through the area, you spot a lone Guard standing at his post. His gaze is fixed outward, scanning the landscape with a practiced vigilance.
 --ROOM 228 END--
 --ROOM 229 START--
 The Tower
 0,228,230,0
-   Old, broken crates are stacked haphazardly along the walls, their weathered
- wood suggesting they've been long forgotten.
+Old, broken crates are stacked haphazardly along the walls, their weathered wood suggesting they've been long forgotten.
 --ROOM 229 END--
 --ROOM 230 START--
 The Tower
 231,0,0,229
-   You step into a makeshift bedroom, its spartan arrangement dominated by
- several simple beds. Clearly, this space serves those who keep watch.
+You step into a makeshift bedroom, its spartan arrangement dominated by several simple beds. Clearly, this space serves those who keep watch.
 --ROOM 230 END--
 --ROOM 231 START--
 The Tower
 232,230,0,0
-   A weary Guard sits slouched in a chair, taking a brief respite from his
- duties. His posture suggests a rare moment of relaxation.
+A weary Guard sits slouched in a chair, taking a brief respite from his duties. His posture suggests a rare moment of relaxation.
 --ROOM 231 END--
 --ROOM 232 START--
 The Tower
 233,231,0,0
-   The sound of the wind rises as you approach the castle's upper exit. Beyond
- lies the unknown, a fate waiting to unfold with your next step.
+The sound of the wind rises as you approach the castle's upper exit. Beyond lies the unknown, a fate waiting to unfold with your next step.
 --ROOM 232 END--
 --ROOM 233 START--
 The Tower
 0,232,0,234
-   As the world around you grows ever darker, an oppressive chill settles in
- the air, intensifying the longer you remain outside.
+As the world around you grows ever darker, an oppressive chill settles in the air, intensifying the longer you remain outside.
 --ROOM 233 END--
 --ROOM 234 START--
 The Tower
 0,0,233,235
-   A deafening crack of lightning splits the sky, the sudden brilliance
- momentarily blinding you.
+A deafening crack of lightning splits the sky, the sudden brilliance momentarily blinding you.
 --ROOM 234 END--
 --ROOM 235 START--
 The Tower
 0,0,234,236
-   The ancient stone walkway is uneven, its timeworn stones bulging and
- shifting beneath your steps.
+The ancient stone walkway is uneven, its timeworn stones bulging and shifting beneath your steps.
 --ROOM 235 END--
 --ROOM 236 START--
 The Tower
 0,237,235,243
-   A startled Guard stands before you, his surprise evident as he takes in your
- unexpected presence.
+A startled Guard stands before you, his surprise evident as he takes in your unexpected presence.
 --ROOM 236 END--
 --ROOM 237 START--
 The Tower
 236,238,0,0
-   Pushing open the creaking wooden door, you step into what seems to be a
- cluttered storage room.
+Pushing open the creaking wooden door, you step into what seems to be a cluttered storage room.
 --ROOM 237 END--
 --ROOM 238 START--
 The Tower
 237,239,0,240
-   You find yourself alone in this desolate, somber place, the emptiness
- pressing heavily upon you.
+You find yourself alone in this desolate, somber place, the emptiness pressing heavily upon you.
 --ROOM 238 END--
 --ROOM 239 START--
 The Tower
 238,226,0,0
-   Standing in utter silence, you watch as the flickering glow of your lantern
- barely keeps the encroaching darkness at bay.
+Standing in utter silence, you watch as the flickering glow of your lantern barely keeps the encroaching darkness at bay.
 --ROOM 239 END--
 --ROOM 240 START--
 The Tower
 0,0,238,241
-   A weary Lookout greets you, his eyes shadowed from what must be countless
- sleepless nights.
+A weary Lookout greets you, his eyes shadowed from what must be countless sleepless nights.
 --ROOM 240 END--
 --ROOM 241 START--
 The Tower
 0,242,240,0
-   Faint strains of music drift through the air. A long-unused firepit lies
- cold and abandoned in the center of the room.
+Faint strains of music drift through the air. A long-unused firepit lies cold and abandoned in the center of the room.
 --ROOM 241 END--
 --ROOM 242 START--
 The Tower
 241,224,0,0
-   The Bard's melody grows louder, but the solitude of your surroundings
- remains unbroken.
+The Bard's melody grows louder, but the solitude of your surroundings remains unbroken.
 --ROOM 242 END--
 --ROOM 243 START--
 The Tower
 244,0,236,0
-   The wind howls mournfully as you tread along the uneven stone walkway.
+The wind howls mournfully as you tread along the uneven stone walkway.
 --ROOM 243 END--
 --ROOM 244 START--
 The Tower
 245,243,0,0
-   Ahead, a stone suddenly breaks free and crashes to the ground below. You
- pause, questioning whether to proceed.
+Ahead, a stone suddenly breaks free and crashes to the ground below. You pause, questioning whether to proceed.
 --ROOM 244 END--
 --ROOM 245 START--
 The Tower
 246,244,0,0
-   In the distance, lightning illuminates the horizon, its jagged brilliance
- sending a shiver of dread down your spine.
+In the distance, lightning illuminates the horizon, its jagged brilliance sending a shiver of dread down your spine.
 --ROOM 245 END--
 --ROOM 246 START--
 The Tower
 253,245,247,0
-   Your steps falter as you spot a Guard lying lifeless on the ground, struck
- down by an unknown force.
+Your steps falter as you spot a Guard lying lifeless on the ground, struck down by an unknown force.
 --ROOM 246 END--
 --ROOM 247 START--
 The Tower
 0,0,248,246
-   The floor is marred with deep scratch marks, and the air reeks of death and
- decay.
+The floor is marred with deep scratch marks, and the air reeks of death and decay.
 --ROOM 247 END--
 --ROOM 248 START--
 The Tower
 249,0,0,247
-   A piercing scream shatters the silence. Before you stands a winged beast,
- its glowing red eyes locking onto you.
+A piercing scream shatters the silence. Before you stands a winged beast, its glowing red eyes locking onto you.
 --ROOM 248 END--
 --ROOM 249 START--
 The Tower
 250,248,0,0
-   ôThis place is cursed,ö you think, convinced that not all truths have been
- revealed to you.
+ôThis place is cursed,ö you think, convinced that not all truths have been revealed to you.
 --ROOM 249 END--
 --ROOM 250 START--
 The Tower
 0,249,0,251
-   Only the howling wind greets you. Your attention is drawn to a cryptic
- message scrawled in ash upon the floor.
+Only the howling wind greets you. Your attention is drawn to a cryptic message scrawled in ash upon the floor.
 --ROOM 250 END--
 --ROOM 251 START--
 The Tower
 0,0,250,252
-   You stand at the lookout point, the forest stretching endlessly before you,
- with distant vistas just visible beyond its edges.
+You stand at the lookout point, the forest stretching endlessly before you, with distant vistas just visible beyond its edges.
 --ROOM 251 END--
 --ROOM 252 START--
 The Tower
 0,253,251,0
-   As you wander, silence and death are your only companions in this forsaken
- place.
+As you wander, silence and death are your only companions in this forsaken place.
 --ROOM 252 END--
 --ROOM 253 START--
 The Tower
 252,246,0,0
-   An icy dread seeps into your bones as you move through this silent, lifeless
- world, each step echoing in the void.
+An icy dread seeps into your bones as you move through this silent, lifeless world, each step echoing in the void.
 --ROOM 253 END--
 --ROOM 254 START--
 The Labyrinth
 0,0,221,255
-   You find yourself standing at the entrance of a sprawling underground
- labyrinth, its shadowy corridors stretching into oblivion.
+You find yourself standing at the entrance of a sprawling underground labyrinth, its shadowy corridors stretching into oblivion.
 --ROOM 254 END--
 --ROOM 255 START--
 The Labyrinth
 0,0,254,256
-   The walls of this hollowed-out domain are a deep, oppressive black, refusing
- to reflect even the faintest glow of your lantern.
+The walls of this hollowed-out domain are a deep, oppressive black, refusing to reflect even the faintest glow of your lantern.
 --ROOM 255 END--
 --ROOM 256 START--
 The Labyrinth
 0,0,255,257
-   The wind howls like a mournful wail as you venture deeper into the endless
- abyss.
+The wind howls like a mournful wail as you venture deeper into the endless abyss.
 --ROOM 256 END--
 --ROOM 257 START--
 The Labyrinth
 258,0,256,0
-   A deafening silence surrounds you, gnawing at your sanity and threatening to
- pull you into the depths of madness.
+A deafening silence surrounds you, gnawing at your sanity and threatening to pull you into the depths of madness.
 --ROOM 257 END--
 --ROOM 258 START--
 The Labyrinth
 259,257,0,0
-   As you wander this desolate place, a creeping unease begins to take hold,
- gnawing at the edges of your mind.
+As you wander this desolate place, a creeping unease begins to take hold, gnawing at the edges of your mind.
 --ROOM 258 END--
 --ROOM 259 START--
 The Labyrinth
 0,258,260,300
-   The flickering light of your lantern dances feebly, offering scant comfort
- against the suffocating darkness.
+The flickering light of your lantern dances feebly, offering scant comfort against the suffocating darkness.
 --ROOM 259 END--
 --ROOM 260 START--
 The Labyrinth
 0,0,261,259
-   The labyrinth's twisting corridors seem designed to unmoor the soul, their
- disorienting turns threatening to unravel your grip on reality.
+The labyrinth's twisting corridors seem designed to unmoor the soul, their disorienting turns threatening to unravel your grip on reality.
 --ROOM 260 END--
 --ROOM 261 START--
 The Labyrinth
 262,0,0,260
-   From the depths of the void, twin red eyes pierce the darkness, belonging to
- a creature unknown and utterly malevolent.
+From the depths of the void, twin red eyes pierce the darkness, belonging to a creature unknown and utterly malevolent.
 --ROOM 261 END--
 --ROOM 262 START--
 The Labyrinth
 263,261,0,0
-    The floor is strewn with hay, as though someone-or something-has made this
- place their home. A fellow lost soul, perhaps?
+The floor is strewn with hay, as though someone-or something-has made this place their home. A fellow lost soul, perhaps?
 --ROOM 262 END--
 --ROOM 263 START--
 The Labyrinth
 0,262,264,0
-   A prickling sensation runs down your spine, the unmistakable feeling of
- unseen eyes watching your every move.
+A prickling sensation runs down your spine, the unmistakable feeling of unseen eyes watching your every move.
 --ROOM 263 END--
 --ROOM 264 START--
 The Labyrinth
 265,0,0,263
-   Before you stretches an ancient rope bridge, its frayed strands vanishing
- into an eternity of shadow.
+Before you stretches an ancient rope bridge, its frayed strands vanishing into an eternity of shadow.
 --ROOM 264 END--
 --ROOM 265 START--
 The Labyrinth
 266,264,0,0
-   Each step on the bridge sends it creaking and swaying, the sound echoing
- ominously in the vast emptiness.
+Each step on the bridge sends it creaking and swaying, the sound echoing ominously in the vast emptiness.
 --ROOM 265 END--
 --ROOM 266 START--
 The Labyrinth
 267,265,0,0
-   In the distance, faint but unmistakable, a pair of glowing red eyes pierce
- the shroud of darkness, watching.
+In the distance, faint but unmistakable, a pair of glowing red eyes pierce the shroud of darkness, watching.
 --ROOM 266 END--
 --ROOM 267 START--
 The Labyrinth
 268,266,0,0
-   The oppressive quiet amplifies your every heartbeat and breath, each sound
- unnervingly loud in the stillness.
+The oppressive quiet amplifies your every heartbeat and breath, each sound unnervingly loud in the stillness.
 --ROOM 267 END--
 --ROOM 268 START--
 The Labyrinth
 271,267,0,269
-   A piercing cry echoes from the distance-a bat, its presence a fleeting
- shadow in this desolate place.
+A piercing cry echoes from the distance-a bat, its presence a fleeting shadow in this desolate place.
 --ROOM 268 END--
 --ROOM 269 START--
 The Labyrinth
 270,0,268,0
-   Carved into the labyrinth walls, you see small stone dwellings, their simple
- design hinting at long-forgotten inhabitants.
+Carved into the labyrinth walls, you see small stone dwellings, their simple design hinting at long-forgotten inhabitants.
 --ROOM 269 END--
 --ROOM 270 START--
 The Labyrinth
 273,269,271,0
-   You step into one of the stone-carved homes. Inside, you find only a modest
- bed, its occupant conspicuously absent.
+You step into one of the stone-carved homes. Inside, you find only a modest bed, its occupant conspicuously absent.
 --ROOM 270 END--
 --ROOM 271 START--
 The Labyrinth
 272,268,0,270
-   The pervasive darkness begins to toy with your mind, and in its depths, you
- hear a voice calling your name.
+The pervasive darkness begins to toy with your mind, and in its depths, you hear a voice calling your name.
 --ROOM 271 END--
 --ROOM 272 START--
 The Labyrinth
 274,271,0,273
-   The rope bridge sways precariously. Through the cracks between its planks,
- you glimpse the glowing red eyes of a Torvenis lurking below.
+The rope bridge sways precariously. Through the cracks between its planks, you glimpse the glowing red eyes of a Torvenis lurking below.
 --ROOM 272 END--
 --ROOM 273 START--
 The Labyrinth
 0,270,272,0
-   Scratches mar the walls of this space, desperate marks left by someone who
- perhaps tried to claim this place as home.
+Scratches mar the walls of this space, desperate marks left by someone who perhaps tried to claim this place as home.
 --ROOM 273 END--
 --ROOM 274 START--
 The Labyrinth
 275,272,0,0
-   You pause, a putrid smell wafting through the air, the unmistakable stench
- of death lingering in this ever-changing maze.
+You pause, a putrid smell wafting through the air, the unmistakable stench of death lingering in this ever-changing maze.
 --ROOM 274 END--
 --ROOM 275 START--
 The Labyrinth
 276,274,0,0
-   On the far side of the rope bridge, you are met by a Dwellem, their form
- both haunting and mysterious.
+On the far side of the rope bridge, you are met by a Dwellem, their form both haunting and mysterious.
 --ROOM 275 END--
 --ROOM 276 START--
 The Labyrinth
 277,275,0,0
-   Improvised homes huddle together in this cavernous space, a makeshift refuge
- for those who have fled the surface world.
+Improvised homes huddle together in this cavernous space, a makeshift refuge for those who have fled the surface world.
 --ROOM 276 END--
 --ROOM 277 START--
 The Labyrinth
 0,276,278,0
-   The acrid smell of a meager fire lingers in the air, fueled by whatever
- scraps its keepers could scavenge.
+The acrid smell of a meager fire lingers in the air, fueled by whatever scraps its keepers could scavenge.
 --ROOM 277 END--
 --ROOM 278 START--
 The Labyrinth
 0,0,279,277
-   Small groups of people gather, their faces etched with desperation as they
- struggle to survive against the ever-present threat of predation.
+Small groups of people gather, their faces etched with desperation as they struggle to survive against the ever-present threat of predation.
 --ROOM 278 END--
 --ROOM 279 START--
 The Labyrinth
 0,0,280,278
-   The rhythmic sound of water dripping from the ceiling into the unseen abyss
- below is all that breaks the oppressive silence.
+The rhythmic sound of water dripping from the ceiling into the unseen abyss below is all that breaks the oppressive silence.
 --ROOM 279 END--
 --ROOM 280 START--
 The Labyrinth
 0,0,281,279
-   Out of the corner of your eye, a shadow flits across the edge of your vision
- quick, deliberate, and gone before you can react.
+Out of the corner of your eye, a shadow flits across the edge of your vision quick, deliberate, and gone before you can react.
 --ROOM 280 END--
 --ROOM 281 START--
 The Labyrinth
 0,282,0,280
-   The twisting pathways of this darkened labyrinth seem to sap your strength,
- their oppressive weight pressing down on your spirit.
+The twisting pathways of this darkened labyrinth seem to sap your strength, their oppressive weight pressing down on your spirit.
 --ROOM 281 END--
 --ROOM 282 START--
 The Labyrinth
 281,283,0,0
-   A faint chant drifts through the darkness, distant yet insistent, calling to
- you with an eerie allure.
+A faint chant drifts through the darkness, distant yet insistent, calling to you with an eerie allure.
 --ROOM 282 END--
 --ROOM 283 START--
 The Labyrinth
 282,0,284,0
-   Before you can venture deeper, the ground beneath your feet trembles. A
- hidden wall grinds open, unveiling a secret world shrouded in mystery.
+Before you can venture deeper, the ground beneath your feet trembles. A hidden wall grinds open, unveiling a secret world shrouded in mystery.
 --ROOM 283 END--
 --ROOM 284 START--
 The Labyrinth
 285,0,295,283
-   Your breath catches as you behold an ancient, forgotten temple, its majesty
- hidden for countless years within this desolate place.
+Your breath catches as you behold an ancient, forgotten temple, its majesty hidden for countless years within this desolate place.
 --ROOM 284 END--
 --ROOM 285 START--
 The Labyrinth
 286,284,0,0
-   As you wander further into the depths, the echoes of chanting voices and
- haunting melodies ripple off the walls, enveloping you in their ghostly
- embrace.
+As you wander further into the depths, the echoes of chanting voices and haunting melodies ripple off the walls, enveloping you in their ghostly embrace.
 --ROOM 285 END--
 --ROOM 286 START--
 The Labyrinth
 287,285,0,0
-   The walls are barren, stripped bare long ago, their emptiness telling a tale
- of loss and desolation.
+The walls are barren, stripped bare long ago, their emptiness telling a tale of loss and desolation.
 --ROOM 286 END--
 --ROOM 287 START--
 The Labyrinth
 0,286,288,0
-   This forgotten world lies in quiet ruin, yet it clings to life, sustained by
- the fervent devotion of those who still worship here.
+This forgotten world lies in quiet ruin, yet it clings to life, sustained by the fervent devotion of those who still worship here.
 --ROOM 287 END--
 --ROOM 288 START--
 The Labyrinth
 0,0,289,287
-   Your mind drifts to thoughts of what this place might have been-its walls
- adorned with sacred art, its alcoves filled with treasured relics, now lost to
- time.
+Your mind drifts to thoughts of what this place might have been-its walls adorned with sacred art, its alcoves filled with treasured relics, now lost to time.
 --ROOM 288 END--
 --ROOM 289 START--
 The Labyrinth
 0,290,0,288
-   Near a flickering fire, a lone woman sits in a worn chair, her voice rising
- in a low, steady chant that reverberates through the chamber.
+Near a flickering fire, a lone woman sits in a worn chair, her voice rising in a low, steady chant that reverberates through the chamber.
 --ROOM 289 END--
 --ROOM 290 START--
 The Labyrinth
 289,0,291,0
-   The only thing to meet your gaze is stark emptiness-bare walls, stripped of
- all meaning.
+The only thing to meet your gaze is stark emptiness-bare walls, stripped of all meaning.
 --ROOM 290 END--
 --ROOM 291 START--
 The Labyrinth
 0,292,0,290
-   You stumble upon a sleeping chamber. The neatly made beds, untouched by
- time, seem almost like a whisper of the lives that once dwelled here.
+You stumble upon a sleeping chamber. The neatly made beds, untouched by time, seem almost like a whisper of the lives that once dwelled here.
 --ROOM 291 END--
 --ROOM 292 START--
 The Labyrinth
 291,293,0,0
-   A row of aged wooden tables stands cleaned and prepared. Wooden dishes are
- neatly set, as though awaiting a meal-or a guest.
+A row of aged wooden tables stands cleaned and prepared. Wooden dishes are neatly set, as though awaiting a meal-or a guest.
 --ROOM 292 END--
 --ROOM 293 START--
 The Labyrinth
 292,0,0,294
-   An elderly priest steps forward, his presence quiet but commanding. His
- weathered face tells of years spent keeping this sanctuary alive, against all
- odds.
+An elderly priest steps forward, his presence quiet but commanding. His weathered face tells of years spent keeping this sanctuary alive, against all odds.
 --ROOM 293 END--
 --ROOM 294 START--
 The Labyrinth
 0,0,293,295
-   An altar stands before you, holding a humble offering to a god whose name
- you do not know.
+An altar stands before you, holding a humble offering to a god whose name you do not know.
 --ROOM 294 END--
 --ROOM 295 START--
 The Labyrinth
 0,296,294,284
-   The silence presses in around you, broken only by the faint sound of a
- solitary chant, drifting like a ghost on the stale air.
+The silence presses in around you, broken only by the faint sound of a solitary chant, drifting like a ghost on the stale air.
 --ROOM 295 END--
 --ROOM 296 START--
 The Labyrinth
 295,297,0,0
-   Your wanderings lead you through empty halls and vacant spaces, where
- nothing stirs, not even hope.
+Your wanderings lead you through empty halls and vacant spaces, where nothing stirs, not even hope.
 --ROOM 296 END--
 --ROOM 297 START--
 The Labyrinth
 296,0,298,299
-   With lantern in hand, you step into a crumbling ruin. The shadows seem to
- shift, and the weight of decay presses heavily upon your shoulders.
+With lantern in hand, you step into a crumbling ruin. The shadows seem to shift, and the weight of decay presses heavily upon your shoulders.
 --ROOM 297 END--
 --ROOM 298 START--
 The Labyrinth
 0,0,0,297
-   The path forward is blocked by a pile of rubble, its jagged edges a stark
- reminder of this place's long abandonment.
+The path forward is blocked by a pile of rubble, its jagged edges a stark reminder of this place's long abandonment.
 --ROOM 298 END--
 --ROOM 299 START--
 The Labyrinth
 0,0,297,0
-   A blocked passage lies ahead, the debris partially burying the skeletal
- remains of someone who perished long ago, their story lost to the rubble.
+A blocked passage lies ahead, the debris partially burying the skeletal remains of someone who perished long ago, their story lost to the rubble.
 --ROOM 299 END--
 --ROOM 300 START--
 The Labyrinth
 0,0,259,301
-   Winding through these twisted paths and narrow halls, you feel a deep
- unease, as though the place itself is watching you.
+Winding through these twisted paths and narrow halls, you feel a deep unease, as though the place itself is watching you.
 --ROOM 300 END--
 --ROOM 301 START--
 The Labyrinth
 0,302,300,0
-   The corridors lead you to an unlit chamber. Shadows seem to dance along the
- walls as you step into the oppressive darkness.
+The corridors lead you to an unlit chamber. Shadows seem to dance along the walls as you step into the oppressive darkness.
 --ROOM 301 END--
 --ROOM 302 START--
 The Labyrinth
 301,303,0,0
-   A sudden burst of light blinds you. When your vision clears, you find
- yourself in an unfamiliar time and place, a world beyond your imagining.
+A sudden burst of light blinds you. When your vision clears, you find yourself in an unfamiliar time and place, a world beyond your imagining.
 --ROOM 302 END--
 --ROOM 303 START--
 The Labyrinth
 302,0,0,304
-   The air is thick with the soothing scent of lavender. Without warning,
- flames erupt from the floor, casting eerie, flickering shadows.
+The air is thick with the soothing scent of lavender. Without warning, flames erupt from the floor, casting eerie, flickering shadows.
 --ROOM 303 END--
 --ROOM 304 START--
 The Labyrinth
 0,0,303,305
-   A towering figure stands before you, radiating raw power. It introduces
- itself as Golecn, the ancient protector of this forgotten realm.
+A towering figure stands before you, radiating raw power. It introduces itself as Golecn, the ancient protector of this forgotten realm.
 --ROOM 304 END--
 --ROOM 305 START--
 The Labyrinth
 306,0,304,0
-   You find yourself in a shattered world, a place that defies all notions of
- the surface you once knew.
+You find yourself in a shattered world, a place that defies all notions of the surface you once knew.
 --ROOM 305 END--
 --ROOM 306 START--
 The Labyrinth
 307,305,0,0
-   The ground beneath you darkens to an inky blackness, and the world fades
- away. In its place emerges a radiant, golden landscape.
+The ground beneath you darkens to an inky blackness, and the world fades away. In its place emerges a radiant, golden landscape.
 --ROOM 306 END--
 --ROOM 307 START--
 The Labyrinth
 309,306,0,308
-   You step into a hall of grandeur. Walls of white marble and matching floors
- are adorned with towering golden statues of long-fallen gods.
+You step into a hall of grandeur. Walls of white marble and matching floors are adorned with towering golden statues of long-fallen gods.
 --ROOM 307 END--
 --ROOM 308 START--
 The Labyrinth
 0,0,307,0
-   The balcony stretches before you, offering a breathtaking view of a hidden,
- thriving society that seems untouched by the outside world.
+The balcony stretches before you, offering a breathtaking view of a hidden, thriving society that seems untouched by the outside world.
 --ROOM 308 END--
 --ROOM 309 START--
 The Labyrinth
 0,307,310,0
-   Gentle harp music drifts through the air, blending seamlessly with the
- bustling activity of contented souls.
+Gentle harp music drifts through the air, blending seamlessly with the bustling activity of contented souls.
 --ROOM 309 END--
 --ROOM 310 START--
 The Labyrinth
 331,0,311,309
-   You navigate this vibrant place as an outsider. Among the cheerful crowds, a
- sense of purpose pulls you forward-toward truth buried within.
+You navigate this vibrant place as an outsider. Among the cheerful crowds, a sense of purpose pulls you forward-toward truth buried within.
 --ROOM 310 END--
 --ROOM 311 START--
 The Labyrinth
 0,0,312,310
-   Your path is blocked by a Priestess, her arms raised in a commanding gesture
- as she invokes the spirits to intervene.
+Your path is blocked by a Priestess, her arms raised in a commanding gesture as she invokes the spirits to intervene.
 --ROOM 311 END--
 --ROOM 312 START--
 The Labyrinth
 313,0,0,311
-   In an instant, the world dissolves around you. When clarity returns, you are
- standing amidst utter devastation and ruin.
+In an instant, the world dissolves around you. When clarity returns, you are standing amidst utter devastation and ruin.
 --ROOM 312 END--
 --ROOM 313 START--
 The Labyrinth
 0,312,314,0
-   A cold wind brushes past, carrying with it a profound sense of desolation.
- Bleakness stretches endlessly in every direction.
+A cold wind brushes past, carrying with it a profound sense of desolation. Bleakness stretches endlessly in every direction.
 --ROOM 313 END--
 --ROOM 314 START--
 The Labyrinth
 0,0,315,313
-   Shattered tables and broken crates lie scattered, remnants of a world
- succumbing to decay and neglect.
+Shattered tables and broken crates lie scattered, remnants of a world succumbing to decay and neglect.
 --ROOM 314 END--
 --ROOM 315 START--
 The Labyrinth
 316,0,0,314
-   This place feels like a solemn monument to a realm long lost-a sobering
- reminder of the fragility of the living world.
+This place feels like a solemn monument to a realm long lost-a sobering reminder of the fragility of the living world.
 --ROOM 315 END--
 --ROOM 316 START--
 The Labyrinth
 0,315,317,0
-   Bright light surrounds you, and suddenly you are in a bustling marketplace
- alive with color and motion.
+Bright light surrounds you, and suddenly you are in a bustling marketplace alive with color and motion.
 --ROOM 316 END--
 --ROOM 317 START--
 The Labyrinth
 318,0,0,316
-   The blare of a horn echoes above the lively chatter of villagers, their
- voices weaving a tapestry of daily life.
+The blare of a horn echoes above the lively chatter of villagers, their voices weaving a tapestry of daily life.
 --ROOM 317 END--
 --ROOM 318 START--
 The Labyrinth
 319,317,0,0
-   A strange stillness takes hold. Your attention is drawn to a pipe jutting
- from the wall, carrying a steady stream of water.
+A strange stillness takes hold. Your attention is drawn to a pipe jutting from the wall, carrying a steady stream of water.
 --ROOM 318 END--
 --ROOM 319 START--
 The Labyrinth
 0,318,0,320
-   Life seems to flow around you, indifferent to your presence. Then, with a
- piercing scream, the world plunges into darkness once more.
+Life seems to flow around you, indifferent to your presence. Then, with a piercing scream, the world plunges into darkness once more.
 --ROOM 319 END--
 --ROOM 320 START--
 The Labyrinth
 321,0,319,0
-   Tattered cloth lies at your feet, illuminated by the flickering light of
- your lantern. The shadows press close, whispering of secrets unseen.
+Tattered cloth lies at your feet, illuminated by the flickering light of your lantern. The shadows press close, whispering of secrets unseen.
 --ROOM 320 END--
 --ROOM 321 START--
 The Labyrinth
 322,320,0,0
-   This chamber feels different from the others, as if it bears a darker
- purpose. The air is heavy with the stench of death and decay, clawing at your
- senses.
+This chamber feels different from the others, as if it bears a darker purpose. The air is heavy with the stench of death and decay, clawing at your senses.
 --ROOM 321 END--
 --ROOM 322 START--
 The Labyrinth
 344,321,0,323
-   As you move through the oppressive gloom, a strange unease washes over you.
- Distant whispers echo faintly, their source lost within the walls of this
- labyrinth.
+As you move through the oppressive gloom, a strange unease washes over you. Distant whispers echo faintly, their source lost within the walls of this labyrinth.
 --ROOM 322 END--
 --ROOM 323 START--
 The Labyrinth
 0,0,322,324
-   In a sudden and almost otherworldly shift, a figure appears before you: the
- Mycelian Sage, its form seemingly woven from the very fabric of the room.
+In a sudden and almost otherworldly shift, a figure appears before you: the Mycelian Sage, its form seemingly woven from the very fabric of the room.
 --ROOM 323 END--
 --ROOM 324 START--
 The Labyrinth
 0,325,323,332
-   The walls are alive with grotesque growths-mushrooms of unnatural colors and
- slick, clinging slime. This place is a testament to the triumph of filth and
- decay.
+The walls are alive with grotesque growths-mushrooms of unnatural colors and slick, clinging slime. This place is a testament to the triumph of filth and decay.
 --ROOM 324 END--
 --ROOM 325 START--
 The Labyrinth
 324,326,0,0
-   A chill breeze rushes past, stirring the air with foreboding. Beneath your
- feet, the ground trembles and begins to splinter, revealing a yawning chasm
- that threatens to swallow everything.
+A chill breeze rushes past, stirring the air with foreboding. Beneath your feet, the ground trembles and begins to splinter, revealing a yawning chasm that threatens to swallow everything.
 --ROOM 325 END--
 --ROOM 326 START--
 The Labyrinth
 325,0,0,327
-   Gouges and marks mar the walls, desperate traces left by those who once
- sought escape from this unyielding prison.
+Gouges and marks mar the walls, desperate traces left by those who once sought escape from this unyielding prison.
 --ROOM 326 END--
 --ROOM 327 START--
 The Labyrinth
 0,328,326,0
-   A sound grows in the distance-a chorus of laughter that crescendos with
- every step you take. You whirl around, only to find that you are utterly,
- undeniably alone.
+A sound grows in the distance-a chorus of laughter that crescendos with every step you take. You whirl around, only to find that you are utterly, undeniably alone.
 --ROOM 327 END--
 --ROOM 328 START--
 The Labyrinth
 327,0,0,329
-   Clinging to the ceiling with grotesque ease, slime dripping from its gnarled
- limbs, the Mycelian Sage peers down at you with a sinister, knowing grin.
+Clinging to the ceiling with grotesque ease, slime dripping from its gnarled limbs, the Mycelian Sage peers down at you with a sinister, knowing grin.
 --ROOM 328 END--
 --ROOM 329 START--
 The Labyrinth
 0,330,328,0
-   The atmosphere here is oppressively cold, the alien geometry of the walls
- and floor warping your sense of reality.
+The atmosphere here is oppressively cold, the alien geometry of the walls and floor warping your sense of reality.
 --ROOM 329 END--
 --ROOM 330 START--
 The Labyrinth
 329,331,0,0
-   From the unseen corners of the room, voices and laughter swirl around you,
- their teasing tones prying at the edges of your sanity.
+From the unseen corners of the room, voices and laughter swirl around you, their teasing tones prying at the edges of your sanity.
 --ROOM 330 END--
 --ROOM 331 START--
 The Labyrinth
 330,310,0,0
-   Your lantern's glow pierces the darkness, its warm light carving a fragile
- path through the endless shadows.
+Your lantern's glow pierces the darkness, its warm light carving a fragile path through the endless shadows.
 --ROOM 331 END--
 --ROOM 332 START--
 The Labyrinth
 0,0,324,333
-   As your lantern flickers, its light casts haunting shapes upon the walls
- phantasmal forms that seem to mock the doomed.
+As your lantern flickers, its light casts haunting shapes upon the walls phantasmal forms that seem to mock the doomed.
 --ROOM 332 END--
 --ROOM 333 START--
 The Labyrinth
 0,0,332,334
-   A spiraling staircase stretches downward into the abyss, each step carrying
- you deeper into the labyrinth's oppressive embrace.
+A spiraling staircase stretches downward into the abyss, each step carrying you deeper into the labyrinth's oppressive embrace.
 --ROOM 333 END--
 --ROOM 334 START--
 The Labyrinth
 335,0,333,0
-   At the staircase's end, you find yourself in an unexpected space-walls and
- floors clad in glinting metal plates, radiating an oppressive heat like the
- belly of a great furnace.
+At the staircase's end, you find yourself in an unexpected space-walls and floors clad in glinting metal plates, radiating an oppressive heat like the belly of a great furnace.
 --ROOM 334 END--
 --ROOM 335 START--
 The Labyrinth
 336,334,0,0
-   Rust blooms across the metallic surfaces, and the air feels thick, almost
- suffocating. A foreboding weight presses down upon you.
+Rust blooms across the metallic surfaces, and the air feels thick, almost suffocating. A foreboding weight presses down upon you.
 --ROOM 335 END--
 --ROOM 336 START--
 The Labyrinth
 0,335,337,0
-   You freeze as the sound of something scratching and pounding reverberates
- through the walls. Something-or someone-is trying to force its way in.
+You freeze as the sound of something scratching and pounding reverberates through the walls. Something-or someone-is trying to force its way in.
 --ROOM 336 END--
 --ROOM 337 START--
 The Labyrinth
 338,0,0,336
-   With a blinding flash, light from the outside world pierces the gloom. In
- that instant, a ghastly arm reaches through, clawing hungrily at the air
- around you.
+With a blinding flash, light from the outside world pierces the gloom. In that instant, a ghastly arm reaches through, clawing hungrily at the air around you.
 --ROOM 337 END--
 --ROOM 338 START--
 The Labyrinth
 0,337,339,0
-   The walls and floor around you shift and pulse, as if the room itself were
- alive, its movements taunting your presence.
+The walls and floor around you shift and pulse, as if the room itself were alive, its movements taunting your presence.
 --ROOM 338 END--
 --ROOM 339 START--
 The Labyrinth
 0,0,340,338
-   Grinding sounds echo through the passageway, accompanied by faint, agonized
- cries. Each step forward feels heavier than the last.
+Grinding sounds echo through the passageway, accompanied by faint, agonized cries. Each step forward feels heavier than the last.
 --ROOM 339 END--
 --ROOM 340 START--
 The Labyrinth
 0,0,341,339
-   The walls tremble violently, inching closer as the floor undulates beneath
- your feet. The room itself seems intent on crushing you.
+The walls tremble violently, inching closer as the floor undulates beneath your feet. The room itself seems intent on crushing you.
 --ROOM 340 END--
 --ROOM 341 START--
 The Labyrinth
 0,342,0,340
-   By sheer instinct and quick reflexes, you leap to safety, narrowly avoiding
- the room's attempt to close in and claim you.
+By sheer instinct and quick reflexes, you leap to safety, narrowly avoiding the room's attempt to close in and claim you.
 --ROOM 341 END--
 --ROOM 342 START--
 The Labyrinth
 341,0,343,0
-   A cacophony of grinding gears fills the space, their relentless turning
- vibrating through the walls and floor.
+A cacophony of grinding gears fills the space, their relentless turning vibrating through the walls and floor.
 --ROOM 342 END--
 --ROOM 343 START--
 The Labyrinth
 0,344,345,342
-   The darkness retreats, dissolving into an overwhelming brightness that
- consumes your senses entirely.
+The darkness retreats, dissolving into an overwhelming brightness that consumes your senses entirely.
 --ROOM 343 END--
 --ROOM 344 START--
 The Labyrinth
 343,322,0,0
-   Sitting alone on a worn stool, an Adventurer regards you with quiet
- curiosity, their presence both unexpected and unsettling.
+Sitting alone on a worn stool, an Adventurer regards you with quiet curiosity, their presence both unexpected and unsettling.
 --ROOM 344 END--
 --ROOM 345 START--
 The Labyrinth
 346,0,0,343
-   Before you stretches a massive walkway that defies logic, extending
- endlessly into an ever-shifting realm of uncertainty.
+Before you stretches a massive walkway that defies logic, extending endlessly into an ever-shifting realm of uncertainty.
 --ROOM 345 END--
 --ROOM 346 START--
 The Labyrinth
 347,345,0,0
-   The walls shimmer and ripple, alternating between lightless void and radiant
- reflections of a sunlit world.
+The walls shimmer and ripple, alternating between lightless void and radiant reflections of a sunlit world.
 --ROOM 346 END--
 --ROOM 347 START--
 The Labyrinth
 348,346,0,0
-   The gentle glow of your lantern illuminates an entrance to a vast chasm,
- where the distant roar of rushing water echoes ominously.
+The gentle glow of your lantern illuminates an entrance to a vast chasm, where the distant roar of rushing water echoes ominously.
 --ROOM 347 END--
 --ROOM 348 START--
 The Labyrinth
 349,347,0,0
-   Suspended over a void of impenetrable darkness, a rope bridge sways gently
- in an unseen breeze, daring you to cross.
+Suspended over a void of impenetrable darkness, a rope bridge sways gently in an unseen breeze, daring you to cross.
 --ROOM 348 END--
 --ROOM 349 START--
 The Labyrinth
 350,348,0,383
-   Water begins to rise from cracks in the floor, filling the air with a
- chilling dampness. Before you lies a realm best left forgotten.
+Water begins to rise from cracks in the floor, filling the air with a chilling dampness. Before you lies a realm best left forgotten.
 --ROOM 349 END--
 --ROOM 350 START--
 The Labyrinth
 351,349,361,0
-   You stand before a towering, cascading citadel. Vines snake along its walls
- and sprawl across the damp floor, cloaking the structure in nature's grip.
+You stand before a towering, cascading citadel. Vines snake along its walls and sprawl across the damp floor, cloaking the structure in nature's grip.
 --ROOM 350 END--
 --ROOM 351 START--
 The Labyrinth
 352,350,0,0
-   The sound of rushing water echoes through the chambers, each step stirring
- ripples in the ankle-deep flood.
+The sound of rushing water echoes through the chambers, each step stirring ripples in the ankle-deep flood.
 --ROOM 351 END--
 --ROOM 352 START--
 The Labyrinth
 353,351,0,0
-   In the distance, the water churns violently as a shadowy creature darts
- beneath the surface.
+In the distance, the water churns violently as a shadowy creature darts beneath the surface.
 --ROOM 352 END--
 --ROOM 353 START--
 The Labyrinth
 354,352,0,0
-   The air hums with electricity as you ascend a narrow staircase toward a
- mysterious, weathered gate.
+The air hums with electricity as you ascend a narrow staircase toward a mysterious, weathered gate.
 --ROOM 353 END--
 --ROOM 354 START--
 The Labyrinth
 355,353,0,0
-   The crackle of distant lightning cuts through the rising wind, casting
- flickering shadows across the walls.
+The crackle of distant lightning cuts through the rising wind, casting flickering shadows across the walls.
 --ROOM 354 END--
 --ROOM 355 START--
 The Labyrinth
 386,354,0,0
-   A swirling portal looms before you, a hypnotic maelstrom of magic and life
- force.
+A swirling portal looms before you, a hypnotic maelstrom of magic and life force.
 --ROOM 355 END--
 --ROOM 356 START--
 The Labyrinth
 361,0,357,0
-   Here lies a forgotten world, its rocky contours adorned by a distant,
- shimmering waterfall.
+Here lies a forgotten world, its rocky contours adorned by a distant, shimmering waterfall.
 --ROOM 356 END--
 --ROOM 357 START--
 The Labyrinth
 360,0,0,356
-   From the depths of shadow, the glowing yellow eyes of the Mermen pierce the
- darkness.
+From the depths of shadow, the glowing yellow eyes of the Mermen pierce the darkness.
 --ROOM 357 END--
 --ROOM 358 START--
 The Labyrinth
 359,0,0,0
-   Scattered stone pillars stand as crumbling sentinels, remnants of a
- once-mighty ceiling now lost to time.
+Scattered stone pillars stand as crumbling sentinels, remnants of a once-mighty ceiling now lost to time.
 --ROOM 358 END--
 --ROOM 359 START--
 The Labyrinth
 0,358,0,360
-   A weathered stone statue rises before you, its form clad in the corroded
- armor of an ancient army.
+A weathered stone statue rises before you, its form clad in the corroded armor of an ancient army.
 --ROOM 359 END--
 --ROOM 360 START--
 The Labyrinth
 363,357,359,0
-   A world adrift in madness-its twisted, chaotic expanse defies comprehension.
+A world adrift in madness-its twisted, chaotic expanse defies comprehension.
 --ROOM 360 END--
 --ROOM 361 START--
 The Labyrinth
 0,356,0,350
-   The flickering light of your lantern breathes life into the surrounding
- vines, their vibrant hues revealed in flashes of color.
+The flickering light of your lantern breathes life into the surrounding vines, their vibrant hues revealed in flashes of color.
 --ROOM 361 END--
 --ROOM 362 START--
 The Labyrinth
 0,0,363,0
-   This place feels timeless, a hidden sanctuary that stretches endlessly into
- obscurity.
+This place feels timeless, a hidden sanctuary that stretches endlessly into obscurity.
 --ROOM 362 END--
 --ROOM 363 START--
 The Labyrinth
 0,360,364,362
-   Broken crates lie submerged in the water. From the corner of your eye, you
- catch a fleeting glimpse of something slipping away.
+Broken crates lie submerged in the water. From the corner of your eye, you catch a fleeting glimpse of something slipping away.
 --ROOM 363 END--
 --ROOM 364 START--
 The Labyrinth
 365,0,0,363
-   The water rises steadily around you, and faintly, you hear the distant sound
- of a voice calling your name.
+The water rises steadily around you, and faintly, you hear the distant sound of a voice calling your name.
 --ROOM 364 END--
 --ROOM 365 START--
 The Labyrinth
 0,364,0,366
-   Ruined statues and shattered stones litter the winding paths, testaments to
- an age long gone.
+Ruined statues and shattered stones litter the winding paths, testaments to an age long gone.
 --ROOM 365 END--
 --ROOM 366 START--
 The Labyrinth
 369,0,365,0
-   In the distance, desperate cries echo through the gloom, pulling you deeper
- into the labyrinth.
+In the distance, desperate cries echo through the gloom, pulling you deeper into the labyrinth.
 --ROOM 366 END--
 --ROOM 367 START--
 The Labyrinth
 368,0,0,0
-   You reach the source of the cries: a weary adventurer, slumped against a
- wall, delirious and barely clinging to consciousness.
+You reach the source of the cries: a weary adventurer, slumped against a wall, delirious and barely clinging to consciousness.
 --ROOM 367 END--
 --ROOM 368 START--
 The Labyrinth
 0,367,369,0
-   The ground shifts unnaturally beneath your feet, as if the very earth here
- is alive and restless.
+The ground shifts unnaturally beneath your feet, as if the very earth here is alive and restless.
 --ROOM 368 END--
 --ROOM 369 START--
 The Labyrinth
 0,366,370,368
-   This ceaseless trek through an unending realm gnaws at your sanity, the
- oppressive atmosphere driving you to the brink.
+This ceaseless trek through an unending realm gnaws at your sanity, the oppressive atmosphere driving you to the brink.
 --ROOM 369 END--
 --ROOM 370 START--
 The Labyrinth
 0,0,0,369
-   A shallow stream winds beneath a crumbling wall, its cool water rushing
- between your feet.
+A shallow stream winds beneath a crumbling wall, its cool water rushing between your feet.
 --ROOM 370 END--
 --ROOM 371 START--
 The Labyrinth
 0,376,0,372
-   The steady drip of water echoes through the stillness, amplifying the eerie
- quiet of this desolate place.
+The steady drip of water echoes through the stillness, amplifying the eerie quiet of this desolate place.
 --ROOM 371 END--
 --ROOM 372 START--
 The Labyrinth
 0,0,371,373
-   The crumbling ruins surrender to the rising water, a cold tomb slowly
- sealing its secrets away.
+The crumbling ruins surrender to the rising water, a cold tomb slowly sealing its secrets away.
 --ROOM 372 END--
 --ROOM 373 START--
 The Labyrinth
 0,374,372,0
-   The ground trembles violently as a Merman leaps from the water, clinging to
- the walls with feral intensity, poised to strike.
+The ground trembles violently as a Merman leaps from the water, clinging to the walls with feral intensity, poised to strike.
 --ROOM 373 END--
 --ROOM 374 START--
 The Labyrinth
 373,0,375,0
-   A foul stench of decay fills the air as you come upon a grisly dumping
- ground for the dead.
+A foul stench of decay fills the air as you come upon a grisly dumping ground for the dead.
 --ROOM 374 END--
 --ROOM 375 START--
 The Labyrinth
 0,378,0,374
-   The walls before you shudder and collapse, sending a cascade of debris into
- the murky water.
+The walls before you shudder and collapse, sending a cascade of debris into the murky water.
 --ROOM 375 END--
 --ROOM 376 START--
 The Labyrinth
 371,377,0,0
-   From beneath the water, the stone floor crumbles into nothingness, draining
- the flood as the room threatens to collapse.
+From beneath the water, the stone floor crumbles into nothingness, draining the flood as the room threatens to collapse.
 --ROOM 376 END--
 --ROOM 377 START--
 The Labyrinth
 376,0,0,0
-   This realm fades endlessly into darkness, its twisting paths looping back on
- themselves in maddening circles.
+This realm fades endlessly into darkness, its twisting paths looping back on themselves in maddening circles.
 --ROOM 377 END--
 --ROOM 378 START--
 The Labyrinth
 375,0,0,379
-   The ceiling groans and fractures, chunks of stone crashing down as the world
- teeters on the brink of destruction.
+The ceiling groans and fractures, chunks of stone crashing down as the world teeters on the brink of destruction.
 --ROOM 378 END--
 --ROOM 379 START--
 The Labyrinth
 0,380,378,0
-   In this watery tomb, the walls seem to dissolve before your eyes, stone and
- memory fading into oblivion.
+In this watery tomb, the walls seem to dissolve before your eyes, stone and memory fading into oblivion.
 --ROOM 379 END--
 --ROOM 380 START--
 The Labyrinth
 379,385,0,0
-   With every step, the water deepens, the suffocating darkness pressing in
- closer with each passing moment.
+With every step, the water deepens, the suffocating darkness pressing in closer with each passing moment.
 --ROOM 380 END--
 --ROOM 381 START--
 The Labyrinth
 0,384,382,0
-   Broken statues litter the path-a silent burial ground for an ancient
- civilization, its legacy eroded by time.
+Broken statues litter the path-a silent burial ground for an ancient civilization, its legacy eroded by time.
 --ROOM 381 END--
 --ROOM 382 START--
 The Labyrinth
 0,383,0,381
-   The walls are alive with color, adorned with intricate designs and
- characters that tell the long-forgotten stories of the dead.
+The walls are alive with color, adorned with intricate designs and characters that tell the long-forgotten stories of the dead.
 --ROOM 382 END--
 --ROOM 383 START--
 The Labyrinth
 382,0,349,0
-   You step into a disturbed tomb, its sacred stillness shattered by the
- passage of time and decay.
+You step into a disturbed tomb, its sacred stillness shattered by the passage of time and decay.
 --ROOM 383 END--
 --ROOM 384 START--
 The Labyrinth
 381,0,0,385
-   The narrow passages twist endlessly, their stone walls closing in as you
- delve deeper into the unknown.
+The narrow passages twist endlessly, their stone walls closing in as you delve deeper into the unknown.
 --ROOM 384 END--
 --ROOM 385 START--
 The Labyrinth
 380,0,384,0
-   Thick vines hang from the walls, writhing and creeping toward you, hungry
- and full of menace.
+Thick vines hang from the walls, writhing and creeping toward you, hungry and full of menace.
 --ROOM 385 END--
 --ROOM 386 START--
 The Labyrinth_: Level Two
 391,355,407,387
-   The steady ticking of a clockwork mechanism echoes eerily through the
- oppressive darkness, each sound amplified by the silent walls of this
- mysterious place.
+The steady ticking of a clockwork mechanism echoes eerily through the oppressive darkness, each sound amplified by the silent walls of this mysterious place.
 --ROOM 386 END--
 --ROOM 387 START--
 The Labyrinth_: Level Two
 0,0,386,388
-   The world around you seems to shift and flow, as if this place is caught in
- a perpetual state of transformation.
+The world around you seems to shift and flow, as if this place is caught in a perpetual state of transformation.
 --ROOM 387 END--
 --ROOM 388 START--
 The Labyrinth_: Level Two
 389,0,387,0
-   In the distance, faintly illuminated, you catch sight of the intricate inner
- workings of what appears to be a massive clock.
+In the distance, faintly illuminated, you catch sight of the intricate inner workings of what appears to be a massive clock.
 --ROOM 388 END--
 --ROOM 389 START--
 The Labyrinth_: Level Two
 0,388,390,0
-   Shrouded in utter darkness, the air around you feels bleak and cold, as if
- hope itself has abandoned this forsaken world.
+Shrouded in utter darkness, the air around you feels bleak and cold, as if hope itself has abandoned this forsaken world.
 --ROOM 389 END--
 --ROOM 390 START--
 The Labyrinth_: Level Two
 0,0,391,389
-   All that surrounds you is silence, broken only by the rhythmic grinding of
- gears turning somewhere unseen.
+All that surrounds you is silence, broken only by the rhythmic grinding of gears turning somewhere unseen.
 --ROOM 390 END--
 --ROOM 391 START--
 The Labyrinth_: Level Two
 392,386,0,390
-   Your path crumbles away into a void of eternal darkness. From your
- precarious vantage point, a distant lantern flickers, its light a fragile
- beacon in the abyss.
+Your path crumbles away into a void of eternal darkness. From your precarious vantage point, a distant lantern flickers, its light a fragile beacon in the abyss.
 --ROOM 391 END--
 --ROOM 392 START--
 The Labyrinth_: Level Two
 393,391,0,0
-   A cool breeze brushes past, making the flame in your lantern flicker and
- dance. A chilling sense of being watched prickles at the edge of your
- awareness.
+A cool breeze brushes past, making the flame in your lantern flicker and dance. A chilling sense of being watched prickles at the edge of your awareness.
 --ROOM 392 END--
 --ROOM 393 START--
 The Labyrinth_: Level Two
 396,392,0,394
-   You come across a pile of rusted metal gears and other ancient components
- remnants of a long-forgotten clockwork device.
+You come across a pile of rusted metal gears and other ancient components remnants of a long-forgotten clockwork device.
 --ROOM 393 END--
 --ROOM 394 START--
 The Labyrinth_: Level Two
 395,0,393,0
-   From within the scattered debris of gears and parts, an Automaton Guardian
- suddenly lunges toward you, its movements sharp and mechanical.
+From within the scattered debris of gears and parts, an Automaton Guardian suddenly lunges toward you, its movements sharp and mechanical.
 --ROOM 394 END--
 --ROOM 395 START--
 The Labyrinth_: Level Two
 406,394,396,0
-   The walls around you shift and groan, moving in strange, unnatural patterns,
- as though the structure itself is alive and in constant motion.
+The walls around you shift and groan, moving in strange, unnatural patterns, as though the structure itself is alive and in constant motion.
 --ROOM 395 END--
 --ROOM 396 START--
 The Labyrinth_: Level Two
 397,393,0,395
-   The ground shudders violently beneath your feet, forcing you to leap onto
- moving platforms in a desperate race against the crumbling terrain.
+The ground shudders violently beneath your feet, forcing you to leap onto moving platforms in a desperate race against the crumbling terrain.
 --ROOM 396 END--
 --ROOM 397 START--
 The Labyrinth_: Level Two
 0,396,0,406
-   This place seems to stretch on endlessly, a labyrinth with no discernible
- end. Who-or what-could have built such an otherworldly structure?
+This place seems to stretch on endlessly, a labyrinth with no discernible end. Who-or what-could have built such an otherworldly structure?
 --ROOM 397 END--
 --ROOM 398 START--
 The Labyrinth_: Level Two
 399,0,0,0
-   You peer into an open chasm, its depths consumed by impenetrable darkness.
- The grinding of unseen gears reverberates ominously from below.
+You peer into an open chasm, its depths consumed by impenetrable darkness. The grinding of unseen gears reverberates ominously from below.
 --ROOM 398 END--
 --ROOM 399 START--
 The Labyrinth_: Level Two
 400,396,0,0
-   The ground quakes as a faceless entity emerges from the shadows, its
- imposing figure radiating an aura of ancient dread.
+The ground quakes as a faceless entity emerges from the shadows, its imposing figure radiating an aura of ancient dread.
 --ROOM 399 END--
 --ROOM 400 START--
 The Labyrinth_: Level Two
 411,0,0,401
-   Water begins to rise with each passing second, lapping at your feet. Your
- lantern's glow is your only solace as the darkness grows deeper and more
- menacing.
+Water begins to rise with each passing second, lapping at your feet. Your lantern's glow is your only solace as the darkness grows deeper and more menacing.
 --ROOM 400 END--
 --ROOM 401 START--
 The Labyrinth_: Level Two
 0,0,400,402
-   A realm unlike any other unfolds before you, dominated by massive,
- interlocking gears that rise and spin in a mesmerizing display of mechanical
- grandeur.
+A realm unlike any other unfolds before you, dominated by massive, interlocking gears that rise and spin in a mesmerizing display of mechanical grandeur.
 --ROOM 401 END--
 --ROOM 402 START--
 The Labyrinth_: Level Two
 0,403,401,0
-   Ascending a creaking flight of stairs, you reach a wall teeming with ancient
- drawings, their meanings shrouded in mystery and time.
+Ascending a creaking flight of stairs, you reach a wall teeming with ancient drawings, their meanings shrouded in mystery and time.
 --ROOM 402 END--
 --ROOM 403 START--
 The Labyrinth_: Level Two
 402,404,0,0
-   You stand in a corridor that seems alive, shifting beneath your feet as if
- propelled by an unseen, colossal gear.
+You stand in a corridor that seems alive, shifting beneath your feet as if propelled by an unseen, colossal gear.
 --ROOM 403 END--
 --ROOM 404 START--
 The Labyrinth_: Level Two
 403,405,0,430
-   Out of the consuming darkness, a ghostly figure materializes, its form
- coalescing before your very eyes, both mesmerizing and haunting.
+Out of the consuming darkness, a ghostly figure materializes, its form coalescing before your very eyes, both mesmerizing and haunting.
 --ROOM 404 END--
 --ROOM 405 START--
 The Labyrinth_: Level Two
 404,0,406,0
-   The walls quiver and slide, revealing hidden chambers. Stripped wallpaper
- clings to the surfaces, worn and faded, whispering of bygone eras.
+The walls quiver and slide, revealing hidden chambers. Stripped wallpaper clings to the surfaces, worn and faded, whispering of bygone eras.
 --ROOM 405 END--
 --ROOM 406 START--
 The Labyrinth_: Level Two
 0,395,397,405
-   Platforms ascend and descend in chaotic rhythm, rising from the void while
- others vanish into the endless abyss below.
+Platforms ascend and descend in chaotic rhythm, rising from the void while others vanish into the endless abyss below.
 --ROOM 406 END--
 --ROOM 407 START--
 The Labyrinth_: Level Two
 0,0,408,399
-   The walls spin and shift in disorienting patterns, morphing the environment
- into the semblance of a constantly transforming village.
+The walls spin and shift in disorienting patterns, morphing the environment into the semblance of a constantly transforming village.
 --ROOM 407 END--
 --ROOM 408 START--
 The Labyrinth_: Level Two
 0,0,409,407
-   Echoes of distant voices swirl around you as the room reshapes itself into
- familiar vistas from the surface world.
+Echoes of distant voices swirl around you as the room reshapes itself into familiar vistas from the surface world.
 --ROOM 408 END--
 --ROOM 409 START--
 The Labyrinth_: Level Two
 0,0,410,408
-   Standing at the village outskirts, you are greeted by a solemn woodsman, his
- presence as weathered and steadfast as the forest beyond.
+Standing at the village outskirts, you are greeted by a solemn woodsman, his presence as weathered and steadfast as the forest beyond.
 --ROOM 409 END--
 --ROOM 410 START--
 The Labyrinth_: Level Two
 0,399,0,409
-   Before you yawns a cavernous opening in the floor, its vast silence pressing
- down upon you with an almost deafening weight.
+Before you yawns a cavernous opening in the floor, its vast silence pressing down upon you with an almost deafening weight.
 --ROOM 410 END--
 --ROOM 411 START--
 The Labyrinth_: Level Two
 0,410,412,0
-   The ground beneath you trembles violently, and with a resounding crack, it
- begins to collapse, tumbling into the dense, swirling mist below.
+The ground beneath you trembles violently, and with a resounding crack, it begins to collapse, tumbling into the dense, swirling mist below.
 --ROOM 411 END--
 --ROOM 412 START--
 The Labyrinth_: Level Two
 0,0,413,411
-   A guttural hiss fills the air, followed by heavy, ragged breaths. Your gaze
- snaps upward, locking with the malevolent eyes of a goblin descending from
- above.
+A guttural hiss fills the air, followed by heavy, ragged breaths. Your gaze snaps upward, locking with the malevolent eyes of a goblin descending from above.
 --ROOM 412 END--
 --ROOM 413 START--
 The Labyrinth_: Level Two
 414,0,0,412
-   Chilled night air streams through shattered windows as gears clank and turn
- rhythmically, filling the room with a cold, mechanical hum.
+Chilled night air streams through shattered windows as gears clank and turn rhythmically, filling the room with a cold, mechanical hum.
 --ROOM 413 END--
 --ROOM 414 START--
 The Labyrinth_: Level Two
 415,413,0,0
-   You step into what was once a bedroom, its faded wallpaper peeling like old
- memories. An empty bed and a timeworn desk stand as solitary witnesses to its
- decay.
+You step into what was once a bedroom, its faded wallpaper peeling like old memories. An empty bed and a timeworn desk stand as solitary witnesses to its decay.
 --ROOM 414 END--
 --ROOM 415 START--
 The Labyrinth_: Level Two
 419,414,416,0
-   Horror grips you as you glimpse a grotesque ghoul hunched over a bizarre
- mechanism, its hands moving with frantic, unnatural speed.
+Horror grips you as you glimpse a grotesque ghoul hunched over a bizarre mechanism, its hands moving with frantic, unnatural speed.
 --ROOM 415 END--
 --ROOM 416 START--
 The Labyrinth_: Level Two
 0,0,417,415
-   Rows of empty bookcases line the walls, standing sentinel in this surreal
- and ever-shifting landscape.
+Rows of empty bookcases line the walls, standing sentinel in this surreal and ever-shifting landscape.
 --ROOM 416 END--
 --ROOM 417 START--
 The Labyrinth_: Level Two
 443,418,0,416
-   The floor splinters and crumbles, plunging into the void as a sinister laugh
- reverberates around you, chilling you to the core.
+The floor splinters and crumbles, plunging into the void as a sinister laugh reverberates around you, chilling you to the core.
 --ROOM 417 END--
 --ROOM 418 START--
 The Labyrinth_: Level Two
 417,0,444,0
-   Candles dot the room, their flickering flames casting dancing shadows from
- the floor, the walls, and every available surface.
+Candles dot the room, their flickering flames casting dancing shadows from the floor, the walls, and every available surface.
 --ROOM 418 END--
 --ROOM 419 START--
 The Labyrinth_: Level Two
 0,415,0,420
-   A winding staircase spirals upward, delivering you into an opulent ballroom,
- resplendent as though untouched by time.
+A winding staircase spirals upward, delivering you into an opulent ballroom, resplendent as though untouched by time.
 --ROOM 419 END--
 --ROOM 420 START--
 The Labyrinth_: Level Two
 0,0,419,421
-   Classical music wafts through the air of the empty palace. As if summoned by
- the melody, ghostly figures emerge, spinning and twirling in spectral dance.
+Classical music wafts through the air of the empty palace. As if summoned by the melody, ghostly figures emerge, spinning and twirling in spectral dance.
 --ROOM 420 END--
 --ROOM 421 START--
 The Labyrinth_: Level Two
 0,0,420,422
-   A massive pendulum swings methodically back and forth, its metallic hum
- resonating through the air as a dense fog begins to coalesce around you.
+A massive pendulum swings methodically back and forth, its metallic hum resonating through the air as a dense fog begins to coalesce around you.
 --ROOM 421 END--
 --ROOM 422 START--
 The Labyrinth_: Level Two
 0,423,421,0
-   You tread cautiously through what seems to be a graveyard of discarded
- clockwork, the rusted remnants of gears and springs scattered like forgotten
- memories.
+You tread cautiously through what seems to be a graveyard of discarded clockwork, the rusted remnants of gears and springs scattered like forgotten memories.
 --ROOM 422 END--
 --ROOM 423 START--
 The Labyrinth_: Level Two
 422,0,0,424
-   Stacks of old wooden crates form precarious towers, and through the creeping
- fog, you catch a glimpse of something shifting in the shadows.
+Stacks of old wooden crates form precarious towers, and through the creeping fog, you catch a glimpse of something shifting in the shadows.
 --ROOM 423 END--
 --ROOM 424 START--
 The Labyrinth_: Level Two
 0,425,423,431
-   The ground beneath your feet crumbles away, revealing a yawning abyss that
- seems to stretch into eternity, swallowing all light.
+The ground beneath your feet crumbles away, revealing a yawning abyss that seems to stretch into eternity, swallowing all light.
 --ROOM 424 END--
 --ROOM 425 START--
 The Labyrinth_: Level Two
 424,0,0,0
-   Shrouded in impenetrable darkness, you catch a fleeting glimmer of light-a
- tempting promise of the surface world above.
+Shrouded in impenetrable darkness, you catch a fleeting glimmer of light-a tempting promise of the surface world above.
 --ROOM 425 END--
 --ROOM 426 START--
 The Labyrinth_: Level Two
 0,0,0,427
-   The air grows frigid, and you can see your breath condense in the eerie
- chill that suddenly envelops the room.
+The air grows frigid, and you can see your breath condense in the eerie chill that suddenly envelops the room.
 --ROOM 426 END--
 --ROOM 427 START--
 The Labyrinth_: Level Two
 0,428,426,0
-   A realm alien to your own stretches before you, and from the ground rises a
- faceless entity, its silent presence both unsettling and mesmerizing.
+A realm alien to your own stretches before you, and from the ground rises a faceless entity, its silent presence both unsettling and mesmerizing.
 --ROOM 427 END--
 --ROOM 428 START--
 The Labyrinth_: Level Two
 427,429,0,0
-   You stand behind a towering clock face, its hands ticking inexorably
- forward. Moonlight filters through the frosted glass, casting pale, ghostly
- shadows.
+You stand behind a towering clock face, its hands ticking inexorably forward. Moonlight filters through the frosted glass, casting pale, ghostly shadows.
 --ROOM 428 END--
 --ROOM 429 START--
 The Labyrinth_: Level Two
 428,430,0,0
-   A sudden flash of lightning illuminates the room, its searing light
- momentarily banishing the oppressive gloom.
+A sudden flash of lightning illuminates the room, its searing light momentarily banishing the oppressive gloom.
 --ROOM 429 END--
 --ROOM 430 START--
 The Labyrinth_: Level Two
 429,0,404,0
-   A ghostly figure materializes before you, catching you off guard with its
- sudden, spectral presence.
+A ghostly figure materializes before you, catching you off guard with its sudden, spectral presence.
 --ROOM 430 END--
 --ROOM 431 START--
 The Labyrinth_: Level Two
 432,0,424,0
-   An icy shiver courses down your spine as you navigate this shifting, surreal
- world that defies comprehension.
+An icy shiver courses down your spine as you navigate this shifting, surreal world that defies comprehension.
 --ROOM 431 END--
 --ROOM 432 START--
 The Labyrinth_: Level Two
 433,431,0,0
-   A section of the wall collapses, revealing a raging storm outside, its
- ferocious winds clawing at the shattered remnants.
+A section of the wall collapses, revealing a raging storm outside, its ferocious winds clawing at the shattered remnants.
 --ROOM 432 END--
 --ROOM 433 START--
 The Labyrinth_: Level Two
 434,432,0,0
-   The room is punctuated by bursts of lightning, their brilliance accompanied
- by the mournful wail of wind howling like a banshee.
+The room is punctuated by bursts of lightning, their brilliance accompanied by the mournful wail of wind howling like a banshee.
 --ROOM 433 END--
 --ROOM 434 START--
 The Labyrinth_: Level Two
 0,433,435,0
-   You stand in a desolate, forsaken space where scattered furniture hints at
- an abandoned attempt to find refuge.
+You stand in a desolate, forsaken space where scattered furniture hints at an abandoned attempt to find refuge.
 --ROOM 434 END--
 --ROOM 435 START--
 The Labyrinth_: Level Two
 0,0,436,434
-   An ancient, threadbare carpet covers the floor, and an old bed leans
- forlornly against the wall, its sagging frame speaking of forgotten rest.
+An ancient, threadbare carpet covers the floor, and an old bed leans forlornly against the wall, its sagging frame speaking of forgotten rest.
 --ROOM 435 END--
 --ROOM 436 START--
 The Labyrinth_: Level Two
 0,0,437,435
-   A rudimentary cooking area emerges before you, dominated by a small, rusty
- stove that seems eager for purpose once more.
+A rudimentary cooking area emerges before you, dominated by a small, rusty stove that seems eager for purpose once more.
 --ROOM 436 END--
 --ROOM 437 START--
 The Labyrinth_: Level Two
 0,0,438,436
-   As you wander through the oppressive silence, faint traces of a disembodied
- conversation echo faintly through the halls.
+As you wander through the oppressive silence, faint traces of a disembodied conversation echo faintly through the halls.
 --ROOM 437 END--
 --ROOM 438 START--
 The Labyrinth_: Level Two
 0,0,439,437
-   The sharp sound of a crash reverberates through the stone corridors, each
- echo amplifying the sense of foreboding.
+The sharp sound of a crash reverberates through the stone corridors, each echo amplifying the sense of foreboding.
 --ROOM 438 END--
 --ROOM 439 START--
 The Labyrinth_: Level Two
 0,440,0,438
-   The walls around you crumble further, revealing an ominous wilderness
- cloaked in impenetrable darkness.
+The walls around you crumble further, revealing an ominous wilderness cloaked in impenetrable darkness.
 --ROOM 439 END--
 --ROOM 440 START--
 The Labyrinth_: Level Two
 439,0,441,0
-   A narrow passage winds before you, leading to a hidden corridor cloaked in
- mystery and intrigue.
+A narrow passage winds before you, leading to a hidden corridor cloaked in mystery and intrigue.
 --ROOM 440 END--
 --ROOM 441 START--
 The Labyrinth_: Level Two
 0,0,0,440
-   The flame of your lantern flickers and dances wildly, buffeted by an unseen
- wind in the cool night air.
+The flame of your lantern flickers and dances wildly, buffeted by an unseen wind in the cool night air.
 --ROOM 441 END--
 --ROOM 442 START--
 The Labyrinth_: Level Two
 447,0,0,443
-   Each step through this foreboding space seems to edge you closer to an
- inexorable, shadowy demise.
+Each step through this foreboding space seems to edge you closer to an inexorable, shadowy demise.
 --ROOM 442 END--
 --ROOM 443 START--
 The Labyrinth_: Level Two
 442,0,442,0
-   Gaping holes pockmark the floor, each a treacherous trap threatening to
- plunge the unwary into the endless void below.
+Gaping holes pockmark the floor, each a treacherous trap threatening to plunge the unwary into the endless void below.
 --ROOM 443 END--
 --ROOM 444 START--
 The Labyrinth_: Level Two
 445,0,0,418
-   You wander through the barren streets of an abandoned village, the silence
- pressing heavily around you.
+You wander through the barren streets of an abandoned village, the silence pressing heavily around you.
 --ROOM 444 END--
 --ROOM 445 START--
 The Labyrinth_: Level Two
 454,444,446,0
-   Broken carts lie scattered across the streets, their decay accompanied by a
- foul stench that clings to the air.
+Broken carts lie scattered across the streets, their decay accompanied by a foul stench that clings to the air.
 --ROOM 445 END--
 --ROOM 446 START--
 The Labyrinth_: Level Two
 0,0,447,445
-   The faint creak of window shutters swaying gently in the wind echoes through
- the empty village.
+The faint creak of window shutters swaying gently in the wind echoes through the empty village.
 --ROOM 446 END--
 --ROOM 447 START--
 The Labyrinth_: Level Two
 448,442,0,446
-   The uneven cobblestone streets force you to slow your steps, each one a
- reminder of the village's disrepair.
+The uneven cobblestone streets force you to slow your steps, each one a reminder of the village's disrepair.
 --ROOM 447 END--
 --ROOM 448 START--
 The Labyrinth_: Level Two
 449,447,0,0
-   An old tavern stands in decay, its windows boarded and its weathered sign
- still swaying faintly, as if beckoning a long-forgotten crowd.
+An old tavern stands in decay, its windows boarded and its weathered sign still swaying faintly, as if beckoning a long-forgotten crowd.
 --ROOM 448 END--
 --ROOM 449 START--
 The Labyrinth_: Level Two
 450,448,0,0
-   A deep unease settles in your stomach. This place feels like a standing
- tombstone, a memorial to forgotten lives.
+A deep unease settles in your stomach. This place feels like a standing tombstone, a memorial to forgotten lives.
 --ROOM 449 END--
 --ROOM 450 START--
 The Labyrinth_: Level Two
 0,449,457,451
-   The sensation of unseen eyes upon you grows stronger as you wander these
- lifeless streets.
+The sensation of unseen eyes upon you grows stronger as you wander these lifeless streets.
 --ROOM 450 END--
 --ROOM 451 START--
 The Labyrinth_: Level Two
 0,452,450,0
-   A thick fog rolls in, enveloping the village in an oppressive shroud. Soon,
- you are lost within its depths.
+A thick fog rolls in, enveloping the village in an oppressive shroud. Soon, you are lost within its depths.
 --ROOM 451 END--
 --ROOM 452 START--
 The Labyrinth_: Level Two
 451,453,0,455
-   A distant church bell tolls within the fog, its mournful sound sending a
- shiver down your spine.
+A distant church bell tolls within the fog, its mournful sound sending a shiver down your spine.
 --ROOM 452 END--
 --ROOM 453 START--
 The Labyrinth_: Level Two
 452,0,0,454
-   In the center of the village, you find a weathered well, its stone edges
- worn smooth by time.
+In the center of the village, you find a weathered well, its stone edges worn smooth by time.
 --ROOM 453 END--
 --ROOM 454 START--
 The Labyrinth_: Level Two
 0,445,453,0
-   The silence here is deafening, broken only by the oppressive presence of
- abandoned buildings that seem to watch your every move.
+The silence here is deafening, broken only by the oppressive presence of abandoned buildings that seem to watch your every move.
 --ROOM 454 END--
 --ROOM 455 START--
 The Labyrinth_: Level Two
 456,0,452,0
-   From somewhere within the fog, the sound of footsteps reaches your ears. You
- are not alone.
+From somewhere within the fog, the sound of footsteps reaches your ears. You are not alone.
 --ROOM 455 END--
 --ROOM 456 START--
 The Labyrinth_: Level Two
 0,455,0,0
-   Your path ends abruptly at an old wooden fence, its boards warped and
- splintered but unyielding.
+Your path ends abruptly at an old wooden fence, its boards warped and splintered but unyielding.
 --ROOM 456 END--
 --ROOM 457 START--
 The Labyrinth_: Level Two
 0,0,458,450
-   You stand before the entrance of an ancient church. The bell tolls again as
- you push open the heavy wooden door, its creak echoing into the emptiness
- within.
+You stand before the entrance of an ancient church. The bell tolls again as you push open the heavy wooden door, its creak echoing into the emptiness within.
 --ROOM 457 END--
 --ROOM 458 START--
 The Labyrinth_: Level Two
 0,0,459,457
-   You step into the church's dimly lit entrance, its brick walls adorned with
- veins of gold that glimmer faintly in the gloom.
+You step into the church's dimly lit entrance, its brick walls adorned with veins of gold that glimmer faintly in the gloom.
 --ROOM 458 END--
 --ROOM 459 START--
 The Labyrinth_: Level Two
 0,460,0,458
-   Flickering candles line the walls, their warm glow waging a quiet battle
- against the encroaching shadows.
+Flickering candles line the walls, their warm glow waging a quiet battle against the encroaching shadows.
 --ROOM 459 END--
 --ROOM 460 START--
 The Labyrinth_: Level Two
 459,461,0,0
-   The rhythmic drip of water echoes from above, mingling with the faint moan
- of wind filtering in from outside.
+The rhythmic drip of water echoes from above, mingling with the faint moan of wind filtering in from outside.
 --ROOM 460 END--
 --ROOM 461 START--
 The Labyrinth_: Level Two
 460,0,462,0
-   Endless rows of pews stretch into eternity, their silence broken by the
- distant, haunting melody of an organ.
+Endless rows of pews stretch into eternity, their silence broken by the distant, haunting melody of an organ.
 --ROOM 461 END--
 --ROOM 462 START--
 The Labyrinth_: Level Two
 0,0,463,461
-   You stand before the worn altar of the ancient church. Without warning, a
- hidden doorway creaks open behind you.
+You stand before the worn altar of the ancient church. Without warning, a hidden doorway creaks open behind you.
 --ROOM 462 END--
 --ROOM 463 START--
 The Labyrinth_: Level Two
 0,464,489,462
-   A narrow tunnel yawns ahead, its depths leading you further into the heart
- of the church's secrets.
+A narrow tunnel yawns ahead, its depths leading you further into the heart of the church's secrets.
 --ROOM 463 END--
 --ROOM 464 START--
 The Labyrinth_: Level Two
 463,465,0,0
-   The walls glisten with condensation, and your lantern flickers weakly,
- struggling to keep the oppressive darkness at bay.
+The walls glisten with condensation, and your lantern flickers weakly, struggling to keep the oppressive darkness at bay.
 --ROOM 464 END--
 --ROOM 465 START--
 The Labyrinth_: Level Two
 464,466,0,0
-   A modest doorway looms before you, its frame barely wide enough to pass
- through.
+A modest doorway looms before you, its frame barely wide enough to pass through.
 --ROOM 465 END--
 --ROOM 466 START--
 The Labyrinth_: Level Two
 465,469,467,468
-   You find yourself at a crossroads, with numerous tunnels branching out in
- every direction, each promising its own mysteries.
+You find yourself at a crossroads, with numerous tunnels branching out in every direction, each promising its own mysteries.
 --ROOM 466 END--
 --ROOM 467 START--
 The Labyrinth_: Level Two
 0,0,478,466
-   Rusted chains dangle from the walls like grim relics of a forgotten dungeon.
+Rusted chains dangle from the walls like grim relics of a forgotten dungeon.
 --ROOM 467 END--
 --ROOM 468 START--
 The Labyrinth_: Level Two
 0,0,466,0
-   The passage ends abruptly at a wall of stone, sealing you in-or perhaps
- locking something out.
+The passage ends abruptly at a wall of stone, sealing you in-or perhaps locking something out.
 --ROOM 468 END--
 --ROOM 469 START--
 The Labyrinth_: Level Two
 466,470,0,0
-   The path narrows further, forcing you to squeeze through the constricting
- stone corridor.
+The path narrows further, forcing you to squeeze through the constricting stone corridor.
 --ROOM 469 END--
 --ROOM 470 START--
 The Labyrinth_: Level Two
 469,0,471,477
-   You emerge into a vast chamber dominated by a massive pit. Torches flicker
- on the walls, casting long, eerie shadows.
+You emerge into a vast chamber dominated by a massive pit. Torches flicker on the walls, casting long, eerie shadows.
 --ROOM 470 END--
 --ROOM 471 START--
 The Labyrinth_: Level Two
 0,472,0,470
-   Time has left this place undisturbed. Dust lies heavy on every surface, a
- testament to its abandonment.
+Time has left this place undisturbed. Dust lies heavy on every surface, a testament to its abandonment.
 --ROOM 471 END--
 --ROOM 472 START--
 The Labyrinth_: Level Two
 471,473,0,0
-   Thick layers of dust coat the walls and floor. The wind whistles through the
- chamber, its tones eerily lifelike as it rises from the pit beside you.
+Thick layers of dust coat the walls and floor. The wind whistles through the chamber, its tones eerily lifelike as it rises from the pit beside you.
 --ROOM 472 END--
 --ROOM 473 START--
 The Labyrinth_: Level Two
 472,0,0,474
-   A chill runs down your spine as you frantically search for an escape from
- the oppressive atmosphere.
+A chill runs down your spine as you frantically search for an escape from the oppressive atmosphere.
 --ROOM 473 END--
 --ROOM 474 START--
 The Labyrinth_: Level Two
 0,490,473,475
-   Before you stands a colossal staircase spiraling downward, leading deeper
- into the labyrinthine underworld.
+Before you stands a colossal staircase spiraling downward, leading deeper into the labyrinthine underworld.
 --ROOM 474 END--
 --ROOM 475 START--
 The Labyrinth_: Level Two
 476,0,474,0
-   The wind's howling intensifies. Out of the corner of your eye, you catch a
- fleeting glimpse of something-or someone-climbing from the pit.
+The wind's howling intensifies. Out of the corner of your eye, you catch a fleeting glimpse of something-or someone-climbing from the pit.
 --ROOM 475 END--
 --ROOM 476 START--
 The Labyrinth_: Level Two
 477,475,0,0
-   Your breath crystallizes in the frigid air as an unnatural coldness creeps
- into your bones.
+Your breath crystallizes in the frigid air as an unnatural coldness creeps into your bones.
 --ROOM 476 END--
 --ROOM 477 START--
 The Labyrinth_: Level Two
 0,476,470,0
-   Clinging to the wall to avoid the pit, you hear the faint, mournful cries of
- a woman echoing from the depths.
+Clinging to the wall to avoid the pit, you hear the faint, mournful cries of a woman echoing from the depths.
 --ROOM 477 END--
 --ROOM 478 START--
 The Labyrinth_: Level Two
 479,0,0,467
-   Water trickles from the walls, and the distant roar of rushing water
- reverberates through the passage.
+Water trickles from the walls, and the distant roar of rushing water reverberates through the passage.
 --ROOM 478 END--
 --ROOM 479 START--
 The Labyrinth_: Level Two
 480,478,0,0
-   A small staircase descends into a shadowy dungeon, its air heavy with the
- weight of despair.
+A small staircase descends into a shadowy dungeon, its air heavy with the weight of despair.
 --ROOM 479 END--
 --ROOM 480 START--
 The Labyrinth_: Level Two
 481,479,0,0
-   The stone walls bear jagged scratch marks, silent evidence of desperate
- attempts to escape.
+The stone walls bear jagged scratch marks, silent evidence of desperate attempts to escape.
 --ROOM 480 END--
 --ROOM 481 START--
 The Labyrinth_: Level Two
 488,480,482,489
-   Massive stone pillars support the ceiling, their surfaces adorned with
- rusting chains that sway ever so slightly.
+Massive stone pillars support the ceiling, their surfaces adorned with rusting chains that sway ever so slightly.
 --ROOM 481 END--
 --ROOM 482 START--
 The Labyrinth_: Level Two
 0,0,483,481
-   Broken buckets lie scattered across the uneven floor, remnants of lives long
- forgotten.
+Broken buckets lie scattered across the uneven floor, remnants of lives long forgotten.
 --ROOM 482 END--
 --ROOM 483 START--
 The Labyrinth_: Level Two
 484,0,0,482
-   A skeleton rests atop a bed of straw, its hollow sockets staring into
- eternity. How long it has been here, none can say.
+A skeleton rests atop a bed of straw, its hollow sockets staring into eternity. How long it has been here, none can say.
 --ROOM 483 END--
 --ROOM 484 START--
 The Labyrinth_: Level Two
 485,483,0,0
-   You stand before a weathered iron cell door, its surface pitted with rust
- and age.
+You stand before a weathered iron cell door, its surface pitted with rust and age.
 --ROOM 484 END--
 --ROOM 485 START--
 The Labyrinth_: Level Two
 0,484,0,486
-   The cell holds nothing but bare stone walls and a meager scattering of hay.
+The cell holds nothing but bare stone walls and a meager scattering of hay.
 --ROOM 485 END--
 --ROOM 486 START--
 The Labyrinth_: Level Two
 0,0,485,487
-   From the oppressive shadows, a gaunt prisoner shuffles toward you, their
- hollow eyes filled with dread.
+From the oppressive shadows, a gaunt prisoner shuffles toward you, their hollow eyes filled with dread.
 --ROOM 486 END--
 --ROOM 487 START--
 The Labyrinth_: Level Two
 0,488,486,0
-   The bleak dungeon offers no reprieve-just more barren chambers that seem to
- mock your presence.
+The bleak dungeon offers no reprieve-just more barren chambers that seem to mock your presence.
 --ROOM 487 END--
 --ROOM 488 START--
 The Labyrinth_: Level Two
 487,481,0,0
-   Old religious symbols are etched into the walls, their intricate designs
- meant to ward off spirits that hunger for souls.
+Old religious symbols are etched into the walls, their intricate designs meant to ward off spirits that hunger for souls.
 --ROOM 488 END--
 --ROOM 489 START--
 The Labyrinth_: Level Two
 0,0,481,463
-   The twisting stone path leads you to the forbidding entrance of a dungeon,
- its gates heavy with foreboding.
+The twisting stone path leads you to the forbidding entrance of a dungeon, its gates heavy with foreboding.
 --ROOM 489 END--
 --ROOM 490 START--
 The Labyrinth_: Level Three
 474,491,0,0
-   You stand on the edge of a murky abyss, gazing down at a swamp shrouded in
- perpetual gloom.
+You stand on the edge of a murky abyss, gazing down at a swamp shrouded in perpetual gloom.
 --ROOM 490 END--
 --ROOM 491 START--
 The Labyrinth_: Level Three
 490,0,492,0
-   The air clings to you like a damp shroud as you wade through the dense,
- oppressive swamp.
+The air clings to you like a damp shroud as you wade through the dense, oppressive swamp.
 --ROOM 491 END--
 --ROOM 492 START--
 The Labyrinth_: Level Three
 0,0,493,491
-   Twisted, lifeless trees loom around you, their skeletal branches like
- grasping claws. A creeping sensation tells you that unseen eyes are watching.
+Twisted, lifeless trees loom around you, their skeletal branches like grasping claws. A creeping sensation tells you that unseen eyes are watching.
 --ROOM 492 END--
 --ROOM 493 START--
 The Labyrinth_: Level Three
 0,494,0,492
-   A cacophony of croaking frogs echoes through the swamp, an eerie symphony in
- the gloom.
+A cacophony of croaking frogs echoes through the swamp, an eerie symphony in the gloom.
 --ROOM 493 END--
 --ROOM 494 START--
 The Labyrinth_: Level Three
 493,495,0,0
-   Pushing through a wall of tangled brush, you catch glimpses of bright,
- erratic flashes of light deep within the swamp's expanse.
+Pushing through a wall of tangled brush, you catch glimpses of bright, erratic flashes of light deep within the swamp's expanse.
 --ROOM 494 END--
 --ROOM 495 START--
 The Labyrinth_: Level Three
 494,496,0,0
-   You step cautiously onto a precarious wooden platform. It creaks and sways
- with the motion of the dark water below.
+You step cautiously onto a precarious wooden platform. It creaks and sways with the motion of the dark water below.
 --ROOM 495 END--
 --ROOM 496 START--
 The Labyrinth_: Level Three
 495,0,0,497
-   With a leap from the teetering platform, you land on a small patch of solid
- ground. A weathered cabin rises before you, its silhouette warped and
- foreboding.
+With a leap from the teetering platform, you land on a small patch of solid ground. A weathered cabin rises before you, its silhouette warped and foreboding.
 --ROOM 496 END--
 --ROOM 497 START--
 The Labyrinth_: Level Three
 0,0,496,498
-   The door creaks ominously as you push it open. Inside, chaos reigns-a place
- abandoned and left to ruin.
+The door creaks ominously as you push it open. Inside, chaos reigns-a place abandoned and left to ruin.
 --ROOM 497 END--
 --ROOM 498 START--
 The Labyrinth_: Level Three
 0,499,497,0
-   Bare walls and a barren floor radiate an unnatural chill, setting your
- nerves on edge.
+Bare walls and a barren floor radiate an unnatural chill, setting your nerves on edge.
 --ROOM 498 END--
 --ROOM 499 START--
 The Labyrinth_: Level Three
 498,500,0,0
-   A crude fire pit is carved into the earth, its ashen remnants hinting at
- recent use.
+A crude fire pit is carved into the earth, its ashen remnants hinting at recent use.
 --ROOM 499 END--
 --ROOM 500 START--
 The Labyrinth_: Level Three
 499,501,0,0
-   From the depths of the swamp, a massive toad emerges, its hungry eyes fixed
- upon you.
+From the depths of the swamp, a massive toad emerges, its hungry eyes fixed upon you.
 --ROOM 500 END--
 --ROOM 501 START--
 The Labyrinth_: Level Three
 500,0,502,0
-   The ground beneath your feet is littered with bones, a grim testament to the
- island's sinister history.
+The ground beneath your feet is littered with bones, a grim testament to the island's sinister history.
 --ROOM 501 END--
 --ROOM 502 START--
 The Labyrinth_: Level Three
 0,505,503,501
-   In the distance, bright flashes of light illuminate the swamp. The air fills
- with a chilling howl-a sound that seems to come from the restless dead.
+In the distance, bright flashes of light illuminate the swamp. The air fills with a chilling howl-a sound that seems to come from the restless dead.
 --ROOM 502 END--
 --ROOM 503 START--
 The Labyrinth_: Level Three
 504,0,0,502
-   The stagnant water erupts as skeletal arms lunge from below, grasping for
- you with cold, unyielding fingers.
+The stagnant water erupts as skeletal arms lunge from below, grasping for you with cold, unyielding fingers.
 --ROOM 503 END--
 --ROOM 504 START--
 The Labyrinth_: Level Three
 0,503,0,0
-   A wall of impenetrable brush blocks your way forward, its twisted vines
- seeming almost alive.
+A wall of impenetrable brush blocks your way forward, its twisted vines seeming almost alive.
 --ROOM 504 END--
 --ROOM 505 START--
 The Labyrinth_: Level Three
 502,506,0,0
-   Knee-high grass whispers against your legs as you approach the swamp's edge,
- where uncertainty hangs as thick as the mist.
+Knee-high grass whispers against your legs as you approach the swamp's edge, where uncertainty hangs as thick as the mist.
 --ROOM 505 END--
 --ROOM 506 START--
 The Labyrinth_: Level Three
 505,508,0,507
-   A world lost to the void, suspended in an endless limbo, its secrets forever
- untold.
+A world lost to the void, suspended in an endless limbo, its secrets forever untold.
 --ROOM 506 END--
 --ROOM 507 START--
 The Labyrinth_: Level Three
 0,0,506,0
-   A low, resonant croak echoes from the swamp, a haunting reminder of the
- dangers that lurk beyond.
+A low, resonant croak echoes from the swamp, a haunting reminder of the dangers that lurk beyond.
 --ROOM 507 END--
 --ROOM 508 START--
 The Labyrinth_: Level Three
 506,0,509,0
-   In the distance, a thin column of smoke twists skyward, a whisper of life or
- warning.
+In the distance, a thin column of smoke twists skyward, a whisper of life or warning.
 --ROOM 508 END--
 --ROOM 509 START--
 The Labyrinth_: Level Three
 0,0,510,508
-   By the crackling fire sits a weary hermit, his face lined with the day's
- toil, resting after a hard day's crab fishing.
+By the crackling fire sits a weary hermit, his face lined with the day's toil, resting after a hard day's crab fishing.
 --ROOM 509 END--
 --ROOM 510 START--
 The Labyrinth_: Level Three
 0,511,0,509
-   As you wander through this uncharted terrain, you find yourself standing
- before an ancient altar, weathered by time.
+As you wander through this uncharted terrain, you find yourself standing before an ancient altar, weathered by time.
 --ROOM 510 END--
 --ROOM 511 START--
 The Labyrinth_: Level Three
 510,512,0,0
-   The ground beneath your feet feels unnervingly solid, as if carved from
- stone, anchoring you to an unnatural stillness.
+The ground beneath your feet feels unnervingly solid, as if carved from stone, anchoring you to an unnatural stillness.
 --ROOM 511 END--
 --ROOM 512 START--
 The Labyrinth_: Level Three
 511,0,513,514
-   All around, the silence of the unknown presses in, and the darkness
- encroaches, swallowing the faintest traces of light.
+All around, the silence of the unknown presses in, and the darkness encroaches, swallowing the faintest traces of light.
 --ROOM 512 END--
 --ROOM 513 START--
 The Labyrinth_: Level Three
 0,0,0,512
-   A void of impenetrable darkness lies ahead; perhaps it is wiser to stay on
- the path you know.
+A void of impenetrable darkness lies ahead; perhaps it is wiser to stay on the path you know.
 --ROOM 513 END--
 --ROOM 514 START--
 The Labyrinth_: Level Three
 0,515,512,0
-   You arrive at a deserted farm, its caretakers mysteriously absent, leaving
- an eerie stillness in their wake.
+You arrive at a deserted farm, its caretakers mysteriously absent, leaving an eerie stillness in their wake.
 --ROOM 514 END--
 --ROOM 515 START--
 The Labyrinth_: Level Three
 514,516,0,0
-   Golden wheat stretches to your knees, swaying gently in the wind as you make
- your way through the fields.
+Golden wheat stretches to your knees, swaying gently in the wind as you make your way through the fields.
 --ROOM 515 END--
 --ROOM 516 START--
 The Labyrinth_: Level Three
 515,0,0,517
-   A sudden flurry of wings cuts through the air, startling you into a panicked
- dive, your heart racing with uncertainty.
+A sudden flurry of wings cuts through the air, startling you into a panicked dive, your heart racing with uncertainty.
 --ROOM 516 END--
 --ROOM 517 START--
 The Labyrinth_: Level Three
 0,0,516,518
-   Crawling through the wheat for cover, you catch sight of a distant farmhouse
- as the hoot of an owl pierces the stillness.
+Crawling through the wheat for cover, you catch sight of a distant farmhouse as the hoot of an owl pierces the stillness.
 --ROOM 517 END--
 --ROOM 518 START--
 The Labyrinth_: Level Three
 519,0,517,520
-   Without hesitation, you step into the farmhouse, finding yourself in a
- small, rudimentary kitchen, its purpose clear yet humble.
+Without hesitation, you step into the farmhouse, finding yourself in a small, rudimentary kitchen, its purpose clear yet humble.
 --ROOM 518 END--
 --ROOM 519 START--
 The Labyrinth_: Level Three
 0,518,0,521
-   This modest sleeping area holds only a single bed and a worn dresser, its
- simplicity telling of a solitary life.
+This modest sleeping area holds only a single bed and a worn dresser, its simplicity telling of a solitary life.
 --ROOM 519 END--
 --ROOM 520 START--
 The Labyrinth_: Level Three
 521,0,518,522
-   Bags of flour, dried fruits, and cured meats fill the storage room, a bounty
- of provisions for the unseen inhabitants.
+Bags of flour, dried fruits, and cured meats fill the storage room, a bounty of provisions for the unseen inhabitants.
 --ROOM 520 END--
 --ROOM 521 START--
 The Labyrinth_: Level Three
 0,520,519,0
-   A farmer greets you, seated in a creaky chair with a book in hand, his gaze
- contemplative and calm.
+A farmer greets you, seated in a creaky chair with a book in hand, his gaze contemplative and calm.
 --ROOM 521 END--
 --ROOM 522 START--
 The Labyrinth_: Level Three
 0,523,520,0
-   The wind howls along a dilapidated path, its destination obscured by shadows
- and the unknown.
+The wind howls along a dilapidated path, its destination obscured by shadows and the unknown.
 --ROOM 522 END--
 --ROOM 523 START--
 The Labyrinth_: Level Three
 522,524,0,0
-   You stand before the gaping maw of a cave, where the howling wind greets you
- like a mournful wail.
+You stand before the gaping maw of a cave, where the howling wind greets you like a mournful wail.
 --ROOM 523 END--
 --ROOM 524 START--
 The Labyrinth_: Level Three
 523,0,525,0
-   The walls glisten with a slick, filmy substance, casting an eerie sheen in
- the dim light.
+The walls glisten with a slick, filmy substance, casting an eerie sheen in the dim light.
 --ROOM 524 END--
 --ROOM 525 START--
 The Labyrinth_: Level Three
 0,528,526,524
-   The rhythmic clanging of something striking the walls echoes through the
- suffocating darkness.
+The rhythmic clanging of something striking the walls echoes through the suffocating darkness.
 --ROOM 525 END--
 --ROOM 526 START--
 The Labyrinth_: Level Three
 0,0,527,525
-   The air is oppressively heavy, laden with an unsettling stillness that
- promises hidden secrets within.
+The air is oppressively heavy, laden with an unsettling stillness that promises hidden secrets within.
 --ROOM 526 END--
 --ROOM 527 START--
 The Labyrinth_: Level Three
 0,0,0,526
-   Patches of thick, clinging webbing spread across the walls, their delicate
- patterns hinting at unseen architects.
+Patches of thick, clinging webbing spread across the walls, their delicate patterns hinting at unseen architects.
 --ROOM 527 END--
 --ROOM 528 START--
 The Labyrinth_: Level Three
 525,529,0,0
-   Each cautious step draws you further into the unknowable depths, where
- shadows seem to hold their breath.
+Each cautious step draws you further into the unknowable depths, where shadows seem to hold their breath.
 --ROOM 528 END--
 --ROOM 529 START--
 The Labyrinth_: Level Three
 528,0,530,0
-   A frantic voice drifts from the darkness ahead, and a robed figure
- materializes just at the edge of your vision.
+A frantic voice drifts from the darkness ahead, and a robed figure materializes just at the edge of your vision.
 --ROOM 529 END--
 --ROOM 530 START--
 The Labyrinth_: Level Three
 0,531,0,529
-   The flickering flame of your lantern casts dancing shadows, barely
- illuminating the treacherous path ahead.
+The flickering flame of your lantern casts dancing shadows, barely illuminating the treacherous path ahead.
 --ROOM 530 END--
 --ROOM 531 START--
 The Labyrinth_: Level Three
 530,539,532,0
-   At the center of the barren chamber lies the skeletal remains of a traveler,
- their final journey ending here.
+At the center of the barren chamber lies the skeletal remains of a traveler, their final journey ending here.
 --ROOM 531 END--
 --ROOM 532 START--
 The Labyrinth_: Level Three
 0,0,533,531
-   Your foot lands in a shallow puddle with a cold splash as you delve further
- into the earth's depths.
+Your foot lands in a shallow puddle with a cold splash as you delve further into the earth's depths.
 --ROOM 532 END--
 --ROOM 533 START--
 The Labyrinth_: Level Three
 534,535,0,532
-   The ground trembles violently. In a panic, you snuff your lantern and
- retreat into the shadows to wait out the quake.
+The ground trembles violently. In a panic, you snuff your lantern and retreat into the shadows to wait out the quake.
 --ROOM 533 END--
 --ROOM 534 START--
 The Labyrinth_: Level Three
 0,533,0,0
-   A vast opening yawns before you, spanned by massive, glistening webs forming
- precarious bridges between the walls.
+A vast opening yawns before you, spanned by massive, glistening webs forming precarious bridges between the walls.
 --ROOM 534 END--
 --ROOM 535 START--
 The Labyrinth_: Level Three
 533,536,0,0
-   A narrow passage leads to a cavern strewn with shattered wood, remnants of
- some forgotten catastrophe.
+A narrow passage leads to a cavern strewn with shattered wood, remnants of some forgotten catastrophe.
 --ROOM 535 END--
 --ROOM 536 START--
 The Labyrinth_: Level Three
 535,0,541,537
-   The air grows damp and oppressive, and thick spider webs cling to the walls
- and dangle ominously from the ceiling.
+The air grows damp and oppressive, and thick spider webs cling to the walls and dangle ominously from the ceiling.
 --ROOM 536 END--
 --ROOM 537 START--
 The Labyrinth_: Level Three
 0,0,536,538
-   A grim tableau greets you: skeletal remains, their brittle forms cloaked in
- a fine layer of undisturbed dust.
+A grim tableau greets you: skeletal remains, their brittle forms cloaked in a fine layer of undisturbed dust.
 --ROOM 537 END--
 --ROOM 538 START--
 The Labyrinth_: Level Three
 539,540,537,0
-   From the shadows ahead comes a chilling sound-the desperate cries of someone
- pleading for mercy.
+From the shadows ahead comes a chilling sound-the desperate cries of someone pleading for mercy.
 --ROOM 538 END--
 --ROOM 539 START--
 The Labyrinth_: Level Three
 531,538,0,0
-   Horror grips you as you spot a cocoon affixed to the wall, a grim reminder
- of the fate that may await.
+Horror grips you as you spot a cocoon affixed to the wall, a grim reminder of the fate that may await.
 --ROOM 539 END--
 --ROOM 540 START--
 The Labyrinth_: Level Three
 538,0,0,0
-   The passage abruptly ends in a dead end. The fetid stench of death hangs
- heavy in the stagnant air.
+The passage abruptly ends in a dead end. The fetid stench of death hangs heavy in the stagnant air.
 --ROOM 540 END--
 --ROOM 541 START--
 The Labyrinth_: Level Three
 0,543,542,536
-   You stand at the mouth of a narrow corridor, its shadowy length drawing you
- deeper into the bowels of the Earth.
+You stand at the mouth of a narrow corridor, its shadowy length drawing you deeper into the bowels of the Earth.
 --ROOM 541 END--
 --ROOM 542 START--
 The Labyrinth_: Level Three
 0,0,0,541
-   A dead end. The faint groan of distant pain reverberates through the
- silence, chilling your resolve.
+A dead end. The faint groan of distant pain reverberates through the silence, chilling your resolve.
 --ROOM 542 END--
 --ROOM 543 START--
 The Labyrinth_: Level Three
 541,544,0,0
-   As you descend further into the earth, the temperature steadily rises, and
- faint, anguished cries echo around you.
+As you descend further into the earth, the temperature steadily rises, and faint, anguished cries echo around you.
 --ROOM 543 END--
 --ROOM 544 START--
 The Labyrinth_: Level Three
 543,545,0,0
-   Delicate spider webs drape the ceiling and walls, their silken threads
- glinting faintly in the dim light.
+Delicate spider webs drape the ceiling and walls, their silken threads glinting faintly in the dim light.
 --ROOM 544 END--
 --ROOM 545 START--
 The Labyrinth_: Level Three
 544,0,0,546
-   Cocoons dangle ominously from the walls of this vile chamber. As you edge
- past, the faint rustling from within sets your nerves on edge.
+Cocoons dangle ominously from the walls of this vile chamber. As you edge past, the faint rustling from within sets your nerves on edge.
 --ROOM 545 END--
 --ROOM 546 START--
 The Labyrinth_: Level Three
 0,548,545,547
-   Encased in oppressive darkness, you freeze as the faint sound of a sinister
- hiss reaches your ears.
+Encased in oppressive darkness, you freeze as the faint sound of a sinister hiss reaches your ears.
 --ROOM 546 END--
 --ROOM 547 START--
 The Labyrinth_: Level Three
 0,0,546,0
-   A dark blur streaks past you, vanishing into the impenetrable shadows of a
- yawning pit.
+A dark blur streaks past you, vanishing into the impenetrable shadows of a yawning pit.
 --ROOM 547 END--
 --ROOM 548 START--
 The Labyrinth_: Level Three
 546,549,0,0
-   A blood-curdling scream freezes you in your tracks. Moments later, a body
- plummets from the ceiling, landing with a sickening thud.
+A blood-curdling scream freezes you in your tracks. Moments later, a body plummets from the ceiling, landing with a sickening thud.
 --ROOM 548 END--
 --ROOM 549 START--
 The Labyrinth_: Level Three
 548,552,550,551
-   The floor is littered with the bones of unfortunate souls. Amid the silence,
- the rhythmic beating of a drum echoes eerily.
+The floor is littered with the bones of unfortunate souls. Amid the silence, the rhythmic beating of a drum echoes eerily.
 --ROOM 549 END--
 --ROOM 550 START--
 The Labyrinth_: Level Three
 0,0,0,549
-   You enter a small, makeshift chamber. An altar of rough wood and stone
- dominates the room, a crude bed rests in the corner, and a priest sits
- solemnly on a simple stool.
+You enter a small, makeshift chamber. An altar of rough wood and stone dominates the room, a crude bed rests in the corner, and a priest sits solemnly on a simple stool.
 --ROOM 550 END--
 --ROOM 551 START--
 The Labyrinth_: Level Three
 0,0,549,0
-   Suspended from the ceiling is a crude effigy, a grotesque semblance of a
- holy spirit created for worship.
+Suspended from the ceiling is a crude effigy, a grotesque semblance of a holy spirit created for worship.
 --ROOM 551 END--
 --ROOM 552 START--
 The Labyrinth_: Level Three
 549,553,0,0
-   The darkness recedes slightly under your lantern's glow, revealing a glint
- of yellow light. It takes a moment to realize something is watching you.
+The darkness recedes slightly under your lantern's glow, revealing a glint of yellow light. It takes a moment to realize something is watching you.
 --ROOM 552 END--
 --ROOM 553 START--
 The Labyrinth_: Level Three
 552,556,555,554
-   The ground beneath your feet slopes treacherously, each step threatening to
- send you sliding uncontrollably into the abyss.
+The ground beneath your feet slopes treacherously, each step threatening to send you sliding uncontrollably into the abyss.
 --ROOM 553 END--
 --ROOM 554 START--
 The Labyrinth_: Level Three
 0,0,553,0
-   You have reached a stark and featureless dead end.
+You have reached a stark and featureless dead end.
 --ROOM 554 END--
 --ROOM 555 START--
 The Labyrinth_: Level Three
 0,0,0,553
-   A foul chamber cluttered with refuse. Broken crates, torn clothing, and
- scraps of trash are strewn chaotically across the floor.
+A foul chamber cluttered with refuse. Broken crates, torn clothing, and scraps of trash are strewn chaotically across the floor.
 --ROOM 555 END--
 --ROOM 556 START--
 The Labyrinth_: Level Three
 553,560,0,0
-   You stand before two imposing stone pillars, their carvings worn by time,
- gazing out into the chaotic expanse of the labyrinth.
+You stand before two imposing stone pillars, their carvings worn by time, gazing out into the chaotic expanse of the labyrinth.
 --ROOM 556 END--
 --ROOM 557 START--
 The Labyrinth_: Level Four
 556,0,558,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 557 END--
 --ROOM 558 START--
 The Labyrinth_: Level Four
 0,0,559,557
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 558 END--
 --ROOM 559 START--
 The Labyrinth_: Level Four
 0,0,560,558
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 559 END--
 --ROOM 560 START--
 The Labyrinth_: Level Four
 556,568,561,559
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 560 END--
 --ROOM 561 START--
 The Labyrinth_: Level Four
 0,0,0,560
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 561 END--
 --ROOM 562 START--
 The Labyrinth_: Level Four
 0,570,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 562 END--
 --ROOM 563 START--
 The Labyrinth_: Level Four
 0,0,564,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 563 END--
 --ROOM 564 START--
 The Labyrinth_: Level Four
 0,572,0,563
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 564 END--
 --ROOM 565 START--
 The Labyrinth_: Level Four
 0,0,566,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 565 END--
 --ROOM 566 START--
 The Labyrinth_: Level Four
 0,574,567,565
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 566 END--
 --ROOM 567 START--
 The Labyrinth_: Level Four
 0,675,568,566
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 567 END--
 --ROOM 568 START--
 The Labyrinth_: Level Four
 560,576,569,567
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 568 END--
 --ROOM 569 START--
 The Labyrinth_: Level Four
 0,577,0,568
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 569 END--
 --ROOM 570 START--
 The Labyrinth_: Level Four
 562,0,571,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 570 END--
 --ROOM 571 START--
 The Labyrinth_: Level Four
 0,0,572,570
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 571 END--
 --ROOM 572 START--
 The Labyrinth_: Level Four
 564,580,0,571
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 572 END--
 --ROOM 573 START--
 The Labyrinth_: Level Four
 0,581,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 573 END--
 --ROOM 574 START--
 The Labyrinth_: Level Four
 566,0,575,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 574 END--
 --ROOM 575 START--
 The Labyrinth_: Level Four
 0,583,0,574
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 575 END--
 --ROOM 576 START--
 The Labyrinth_: Level Four
 568,0,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 576 END--
 --ROOM 577 START--
 The Labyrinth_: Level Four
 569,585,578,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 577 END--
 --ROOM 578 START--
 The Labyrinth_: Level Four
 0,586,579,577
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 578 END--
 --ROOM 579 START--
 The Labyrinth_: Level Four
 0,0,0,578
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 579 END--
 --ROOM 580 START--
 The Labyrinth_: Level Four
 572,0,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 580 END--
 --ROOM 581 START--
 The Labyrinth_: Level Four
 523,589,582,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 581 END--
 --ROOM 582 START--
 The Labyrinth_: Level Four
 0,0,583,581
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 582 END--
 --ROOM 583 START--
 The Labyrinth_: Level Four
 575,0,0,582
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 583 END--
 --ROOM 584 START--
 The Labyrinth_: Level Four
 0,592,585,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 584 END--
 --ROOM 585 START--
 The Labyrinth_: Level Four
 577,0,586,584
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 585 END--
 --ROOM 586 START--
 The Labyrinth_: Level Four
 578,0,0,585
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 586 END--
 --ROOM 587 START--
 The Labyrinth_: Level Four
 0,595,588,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 587 END--
 --ROOM 588 START--
 The Labyrinth_: Level Four
 0,596,0,587
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 588 END--
 --ROOM 589 START--
 The Labyrinth_: Level Four
 581,0,590,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 589 END--
 --ROOM 590 START--
 The Labyrinth_: Level Four
 0,0,591,589
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 590 END--
 --ROOM 591 START--
 The Labyrinth_: Level Four
 0,0,0,590
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 591 END--
 --ROOM 592 START--
 The Labyrinth_: Level Four
 584,600,593,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 592 END--
 --ROOM 593 START--
 The Labyrinth_: Level Four
 0,601,0,592
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 593 END--
 --ROOM 594 START--
 The Labyrinth_: Level Four
 0,602,595,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 594 END--
 --ROOM 595 START--
 The Labyrinth_: Level Four
 587,0,0,594
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 595 END--
 --ROOM 596 START--
 The Labyrinth_: Level Four
 588,604,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 596 END--
 --ROOM 597 START--
 The Labyrinth_: Level Four
 0,605,598,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 597 END--
 --ROOM 598 START--
 The Labyrinth_: Level Four
 0,606,599,597
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 598 END--
 --ROOM 599 START--
 The Labyrinth_: Level Four
 0,0,0,598
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 599 END--
 --ROOM 600 START--
 The Labyrinth_: Level Four
 592,0,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 600 END--
 --ROOM 601 START--
 The Labyrinth_: Level Four
 593,609,602,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 601 END--
 --ROOM 602 START--
 The Labyrinth_: Level Four
 594,0,0,601
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 602 END--
 --ROOM 603 START--
 The Labyrinth_: Level Four
 0,611,604,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 603 END--
 --ROOM 604 START--
 The Labyrinth_: Level Four
 596,0,0,603
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 604 END--
 --ROOM 605 START--
 The Labyrinth_: Level Four
 597,613,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 605 END--
 --ROOM 606 START--
 The Labyrinth_: Level Four
 598,0,607,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 606 END--
 --ROOM 607 START--
 The Labyrinth_: Level Four
 0,615,0,606
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 607 END--
 --ROOM 608 START--
 The Labyrinth_: Level Four
 0,616,609,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 608 END--
 --ROOM 609 START--
 The Labyrinth_: Level Four
 601,617,610,608
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 609 END--
 --ROOM 610 START--
 The Labyrinth_: Level Four
 0,0,0,609
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 610 END--
 --ROOM 611 START--
 The Labyrinth_: Level Four
 603,0,612,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 611 END--
 --ROOM 612 START--
 The Labyrinth_: Level Four
 0,620,0,611
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 612 END--
 --ROOM 613 START--
 The Labyrinth_: Level Four
 605,621,614,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 613 END--
 --ROOM 614 START--
 The Labyrinth_: Level Four
 0,0,0,613
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 614 END--
 --ROOM 615 START--
 The Labyrinth_: Level Four
 607,623,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 615 END--
 --ROOM 616 START--
 The Labyrinth_: Level Four
 608,624,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 616 END--
 --ROOM 617 START--
 The Labyrinth_: Level Four
 609,625,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 617 END--
 --ROOM 618 START--
 The Labyrinth_: Level Four
 0,626,619,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 618 END--
 --ROOM 619 START--
 The Labyrinth_: Level Four
 0,627,0,618
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 619 END--
 --ROOM 620 START--
 The Labyrinth_: Level Four
 612,628,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 620 END--
 --ROOM 621 START--
 The Labyrinth_: Level Four
 613,629,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 621 END--
 --ROOM 622 START--
 The Labyrinth_: Level Four
 0,630,623,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 622 END--
 --ROOM 623 START--
 The Labyrinth_: Level Four
 615,631,0,622
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 623 END--
 --ROOM 624 START--
 The Labyrinth_: Level Four
 616,632,625,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 624 END--
 --ROOM 625 START--
 The Labyrinth_: Level Four
 617,0,626,624
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 625 END--
 --ROOM 626 START--
 The Labyrinth_: Level Four
 618,0,0,625
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 626 END--
 --ROOM 627 START--
 The Labyrinth_: Level Four
 619,0,628,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 627 END--
 --ROOM 628 START--
 The Labyrinth_: Level Four
 620,0,0,627
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 628 END--
 --ROOM 629 START--
 The Labyrinth_: Level Four
 621,637,630,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 629 END--
 --ROOM 630 START--
 The Labyrinth_: Level Four
 622,0,0,629
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 630 END--
 --ROOM 631 START--
 The Labyrinth_: Level Four
 623,0,632,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 631 END--
 --ROOM 632 START--
 The Labyrinth_: Level Four
 624,0,633,631
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 632 END--
 --ROOM 633 START--
 The Labyrinth_: Level Four
 0,0,634,632
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 633 END--
 --ROOM 634 START--
 The Labyrinth_: Level Four
 0,0,635,633
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 634 END--
 --ROOM 635 START--
 The Labyrinth_: Level Four
 0,643,0,634
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 635 END--
 --ROOM 636 START--
 The Labyrinth_: Level Four
 0,644,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 636 END--
 --ROOM 637 START--
 The Labyrinth_: Level Four
 629,641,638,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 637 END--
 --ROOM 638 START--
 The Labyrinth_: Level Four
 0,646,0,637
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 638 END--
 --ROOM 639 START--
 The Labyrinth_: Level Four
 0,0,640,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 639 END--
 --ROOM 640 START--
 The Labyrinth_: Level Four
 0,648,641,639
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 640 END--
 --ROOM 641 START--
 The Labyrinth_: Level Four
 637,649,642,640
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 641 END--
 --ROOM 642 START--
 The Labyrinth_: Level Four
 0,0,643,641
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 642 END--
 --ROOM 643 START--
 The Labyrinth_: Level Four
 635,651,644,642
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 643 END--
 --ROOM 644 START--
 The Labyrinth_: Level Four
 636,0,0,643
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 644 END--
 --ROOM 645 START--
 The Labyrinth_: Level Four
 0,0,646,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 645 END--
 --ROOM 646 START--
 The Labyrinth_: Level Four
 638,654,647,645
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 646 END--
 --ROOM 647 START--
 The Labyrinth_: Level Four
 0,655,0,646
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 647 END--
 --ROOM 648 START--
 The Labyrinth_: Level Four
 640,0,649,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 648 END--
 --ROOM 649 START--
 The Labyrinth_: Level Four
 641,657,0,648
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 649 END--
 --ROOM 650 START--
 The Labyrinth_: Level Four
 0,658,0,649
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 650 END--
 --ROOM 651 START--
 The Labyrinth_: Level Four
 643,0,652,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 651 END--
 --ROOM 652 START--
 The Labyrinth_: Level Four
 0,660,0,651
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 652 END--
 --ROOM 653 START--
 The Labyrinth_: Level Four
 0,661,654,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 653 END--
 --ROOM 654 START--
 The Labyrinth_: Level Four
 646,0,0,653
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 654 END--
 --ROOM 655 START--
 The Labyrinth_: Level Four
 647,663,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 655 END--
 --ROOM 656 START--
 The Labyrinth_: Level Four
 0,664,657,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 656 END--
 --ROOM 657 START--
 The Labyrinth_: Level Four
 649,0,0,656
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 657 END--
 --ROOM 658 START--
 The Labyrinth_: Level Four
 650,666,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 658 END--
 --ROOM 659 START--
 The Labyrinth_: Level Four
 0,667,660,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 659 END--
 --ROOM 660 START--
 The Labyrinth_: Level Four
 652,668,0,659
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 660 END--
 --ROOM 661 START--
 The Labyrinth_: Level Four
 653,669,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 661 END--
 --ROOM 662 START--
 The Labyrinth_: Level Four
 0,670,663,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 662 END--
 --ROOM 663 START--
 The Labyrinth_: Level Four
 655,0,0,662
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 663 END--
 --ROOM 664 START--
 The Labyrinth_: Level Four
 656,0,665,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 664 END--
 --ROOM 665 START--
 The Labyrinth_: Level Four
 0,673,0,664
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 665 END--
 --ROOM 666 START--
 The Labyrinth_: Level Four
 658,0,667,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 666 END--
 --ROOM 667 START--
 The Labyrinth_: Level Four
 659,0,0,666
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 667 END--
 --ROOM 668 START--
 The Labyrinth_: Level Four
 660,0,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 668 END--
 --ROOM 669 START--
 The Labyrinth_: Level Four
 661,0,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 669 END--
 --ROOM 670 START--
 The Labyrinth_: Level Four
 662,678,671,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 670 END--
 --ROOM 671 START--
 The Labyrinth_: Level Four
 0,679,0,670
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 671 END--
 --ROOM 672 START--
 The Labyrinth_: Level Four
 0,680,673,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 672 END--
 --ROOM 673 START--
 The Labyrinth_: Level Four
 665,0,0,672
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 673 END--
 --ROOM 674 START--
 The Labyrinth_: Level Four
 0,682,675,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 674 END--
 --ROOM 675 START--
 The Labyrinth_: Level Four
 667,0,676,674
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 675 END--
 --ROOM 676 START--
 The Labyrinth_: Level Four
 0,684,0,675
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 676 END--
 --ROOM 677 START--
 The Labyrinth_: Level Four
 0,0,678,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 677 END--
 --ROOM 678 START--
 The Labyrinth_: Level Four
 670,0,0,677
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 678 END--
 --ROOM 679 START--
 The Labyrinth_: Level Four
 671,0,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 679 END--
 --ROOM 680 START--
 The Labyrinth_: Level Four
 672,685,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 680 END--
 --ROOM 681 START--
 The Labyrinth_: Level Four
 0,0,682,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 681 END--
 --ROOM 682 START--
 The Labyrinth_: Level Four
 674,0,683,681
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 682 END--
 --ROOM 683 START--
 The Labyrinth_: Level Four
 0,0,0,682
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 683 END--
 --ROOM 684 START--
 The Labyrinth_: Level Four
 676,0,0,0
-   You stand at the edge of uncertainty; the twisting corridors of the maze
- stretch before you, each path whispering promises of secrets and peril.
+You stand at the edge of uncertainty; the twisting corridors of the maze stretch before you, each path whispering promises of secrets and peril.
 --ROOM 684 END--
 --ROOM 685 START--
 The Labyrinth_: Level Five
 680,686,0,0
-   Towering trees surround you, their swaying boughs moving rhythmically as if
- driven by an unseen, powerful wind.
+Towering trees surround you, their swaying boughs moving rhythmically as if driven by an unseen, powerful wind.
 --ROOM 685 END--
 --ROOM 686 START--
 The Labyrinth_: Level Five
 685,0,687,0
-   The twisting, turning path draws you deeper into the heart of the forest,
- each step shrouded in mystery.
+The twisting, turning path draws you deeper into the heart of the forest, each step shrouded in mystery.
 --ROOM 686 END--
 --ROOM 687 START--
 The Labyrinth_: Level Five
 0,689,688,686
-   Faint whispers drift through the air, their source hidden in the shadows
- around you.
+Faint whispers drift through the air, their source hidden in the shadows around you.
 --ROOM 687 END--
 --ROOM 688 START--
 The Labyrinth_: Level Five
 0,0,0,687
-   The ground trembles beneath your feet as fine dust sifts down from the
- labyrinthine ceilings above.
+The ground trembles beneath your feet as fine dust sifts down from the labyrinthine ceilings above.
 --ROOM 688 END--
 --ROOM 689 START--
 The Labyrinth_: Level Five
 687,690,0,0
-   In the distance, the faint silhouette of a figure-or perhaps something
- else-moves through the wild, barely discernible.
+In the distance, the faint silhouette of a figure-or perhaps something else-moves through the wild, barely discernible.
 --ROOM 689 END--
 --ROOM 690 START--
 The Labyrinth_: Level Five
 689,691,0,696
-   As you follow the winding path, an unsettling sensation creeps over you-the
- distinct feeling that you're being watched.
+As you follow the winding path, an unsettling sensation creeps over you-the distinct feeling that you're being watched.
 --ROOM 690 END--
 --ROOM 691 START--
 The Labyrinth_: Level Five
 690,0,692,0
-   The steep trail descends sharply, offering a panoramic view of a valley that
- stretches into uncharted territory.
+The steep trail descends sharply, offering a panoramic view of a valley that stretches into uncharted territory.
 --ROOM 691 END--
 --ROOM 692 START--
 The Labyrinth_: Level Five
 0,0,693,691
-   Each cautious step takes you deeper into an unfamiliar and enigmatic world,
- where the unknown beckons.
+Each cautious step takes you deeper into an unfamiliar and enigmatic world, where the unknown beckons.
 --ROOM 692 END--
 --ROOM 693 START--
 The Labyrinth_: Level Five
 0,694,0,692
-   A small stream flows beside you, its gentle babbling briefly evoking
- memories of the surface world.
+A small stream flows beside you, its gentle babbling briefly evoking memories of the surface world.
 --ROOM 693 END--
 --ROOM 694 START--
 The Labyrinth_: Level Five
 693,0,695,0
-   The path ahead becomes treacherous, obstructed by fallen boulders and
- scattered debris.
+The path ahead becomes treacherous, obstructed by fallen boulders and scattered debris.
 --ROOM 694 END--
 --ROOM 695 START--
 The Labyrinth_: Level Five
 0,0,0,694
-   The ground ahead abruptly drops away, revealing a cliff that offers a
- breathtaking view of the forest canopy far below.
+The ground ahead abruptly drops away, revealing a cliff that offers a breathtaking view of the forest canopy far below.
 --ROOM 695 END--
 --ROOM 696 START--
 The Labyrinth_: Level Five
 0,0,690,697
-   You find yourself surrounded by a world long lost to time, and for a
- fleeting moment, you wonder what secrets it holds.
+You find yourself surrounded by a world long lost to time, and for a fleeting moment, you wonder what secrets it holds.
 --ROOM 696 END--
 --ROOM 697 START--
 The Labyrinth_: Level Five
 0,698,696,0
-   In the distance, a plume of smoke rises skyward, carrying the unmistakable
- scent of burning wood.
+In the distance, a plume of smoke rises skyward, carrying the unmistakable scent of burning wood.
 --ROOM 697 END--
 --ROOM 698 START--
 The Labyrinth_: Level Five
 697,699,0,0
-   Darkness thickens around you, and the flickering flame of your lantern casts
- erratic, dancing shadows.
+Darkness thickens around you, and the flickering flame of your lantern casts erratic, dancing shadows.
 --ROOM 698 END--
 --ROOM 699 START--
 The Labyrinth_: Level Five
 698,701,0,700
-   Encased in an eerie silence, you stand in a place that feels utterly unholy,
- as if the air itself resists your presence.
+Encased in an eerie silence, you stand in a place that feels utterly unholy, as if the air itself resists your presence.
 --ROOM 699 END--
 --ROOM 700 START--
 The Labyrinth_: Level Five
 0,0,699,0
-   An impenetrable line of trees blocks your path, while an eerie glow flickers
- and shifts in the distance.
+An impenetrable line of trees blocks your path, while an eerie glow flickers and shifts in the distance.
 --ROOM 700 END--
 --ROOM 701 START--
 The Labyrinth_: Level Five
 699,702,0,0
-   The ground trembles beneath your feet as you approach the ominous entrance
- to the witch's dungeon, its jagged maw carved into the earth like a dark
- secret waiting to be uncovered.
+The ground trembles beneath your feet as you approach the ominous entrance to the witch's dungeon, its jagged maw carved into the earth like a dark secret waiting to be uncovered.
 --ROOM 701 END--
 --ROOM 702 START--
 The Labyrinth_: Level Five
 701,0,703,0
-   You stand before a vast hall, its soaring arches and intricate carvings
- whispering of a place forged by ancient and powerful magic.
+You stand before a vast hall, its soaring arches and intricate carvings whispering of a place forged by ancient and powerful magic.
 --ROOM 702 END--
 --ROOM 703 START--
 The Labyrinth_: Level Five
 0,704,0,702
-   A haunting melody drifts from a nearby chamber, carried on a breeze laden
- with the delicate scent of an otherworldly perfume.
+A haunting melody drifts from a nearby chamber, carried on a breeze laden with the delicate scent of an otherworldly perfume.
 --ROOM 703 END--
 --ROOM 704 START--
 The Labyrinth_: Level Five
 703,705,0,0
-   Emerging unexpectedly from the shadows, a figure steps forward-a witch's
- apprentice, their friendly smile disarming yet enigmatic.
+Emerging unexpectedly from the shadows, a figure steps forward-a witch's apprentice, their friendly smile disarming yet enigmatic.
 --ROOM 704 END--
 --ROOM 705 START--
 The Labyrinth_: Level Five
 704,0,706,0
-   The walls shudder violently, cracking and crumbling away to reveal a
- breathtaking night sky, its stars shimmering like shards of a fractured dream.
+The walls shudder violently, cracking and crumbling away to reveal a breathtaking night sky, its stars shimmering like shards of a fractured dream.
 --ROOM 705 END--
 --ROOM 706 START--
 The Labyrinth_: Level Five
 0,709,707,705
-   With each step you take, a new star flickers to life in the infinite
- tapestry of the night sky, as if the heavens themselves respond to your
- presence.
+With each step you take, a new star flickers to life in the infinite tapestry of the night sky, as if the heavens themselves respond to your presence.
 --ROOM 706 END--
 --ROOM 707 START--
 The Labyrinth_: Level Five
 708,0,0,706
-   The hallway before you twists and shifts, expanding and contracting as
- though it is a living, breathing entity.
+The hallway before you twists and shifts, expanding and contracting as though it is a living, breathing entity.
 --ROOM 707 END--
 --ROOM 708 START--
 The Labyrinth_: Level Five
 0,707,0,0
-   Before you looms a massive window, framing the vast, untamed wilderness of
- this cursed land, its desolation stretching endlessly beneath a crimson sky.
+Before you looms a massive window, framing the vast, untamed wilderness of this cursed land, its desolation stretching endlessly beneath a crimson sky.
 --ROOM 708 END--
 --ROOM 709 START--
 The Labyrinth_: Level Five
 706,710,0,0
-   The grand ballroom defies all reason, its opulence dazzling and surreal.
- From the ether materializes a specter, its ethereal form both haunting and
- elegant.
+The grand ballroom defies all reason, its opulence dazzling and surreal. From the ether materializes a specter, its ethereal form both haunting and elegant.
 --ROOM 709 END--
 --ROOM 710 START--
 The Labyrinth_: Level Five
 709,0,0,711
-   Darkness engulfs the room entirely, and the faint glow of your lantern is
- the only thing piercing the oppressive blackness.
+Darkness engulfs the room entirely, and the faint glow of your lantern is the only thing piercing the oppressive blackness.
 --ROOM 710 END--
 --ROOM 711 START--
 The Labyrinth_: Level Five
 0,712,710,0
-   Light floods the chamber without warning, and you find yourself in the midst
- of a sprawling field, its grasses shimmering with an unearthly glow.
+Light floods the chamber without warning, and you find yourself in the midst of a sprawling field, its grasses shimmering with an unearthly glow.
 --ROOM 711 END--
 --ROOM 712 START--
 The Labyrinth_: Level Five
 711,714,0,713
-   A frigid breeze brushes past, sending a shiver down your spine, as the
- mournful howl of a wolf echoes through the distance.
+A frigid breeze brushes past, sending a shiver down your spine, as the mournful howl of a wolf echoes through the distance.
 --ROOM 712 END--
 --ROOM 713 START--
 The Labyrinth_: Level Five
 0,0,712,0
-   You stand at the edge of a cliff, overlooking a sky that ripples and flows
- like a celestial river, its colors shifting in mesmerizing patterns.
+You stand at the edge of a cliff, overlooking a sky that ripples and flows like a celestial river, its colors shifting in mesmerizing patterns.
 --ROOM 713 END--
 --ROOM 714 START--
 The Labyrinth_: Level Five
 712,0,715,0
-   From the earth rises a staircase, its jagged steps ascending into an endless
- void, beckoning you toward the unknown.
+From the earth rises a staircase, its jagged steps ascending into an endless void, beckoning you toward the unknown.
 --ROOM 714 END--
 --ROOM 715 START--
 The Labyrinth_: Level Five
 0,716,0,714
-   The world around you churns with ceaseless transformation, the seasons
- shifting violently from scorching summer to icy winter, leaving you in
- constant peril.
+The world around you churns with ceaseless transformation, the seasons shifting violently from scorching summer to icy winter, leaving you in constant peril.
 --ROOM 715 END--
 --ROOM 716 START--
 The Labyrinth_: Level Five
 715,717,0,0
-   A long hallway stretches before you, its eerie silence broken only by the
- lilting sound of a woman's laughter echoing faintly through the air.
+A long hallway stretches before you, its eerie silence broken only by the lilting sound of a woman's laughter echoing faintly through the air.
 --ROOM 716 END--
 --ROOM 717 START--
 The Labyrinth_: Level Five
 716,718,0,0
-   At last, you find yourself before the imposing entrance to the throne room
- of a forgotten kingdom, its massive doors radiating a sense of lost grandeur.
+At last, you find yourself before the imposing entrance to the throne room of a forgotten kingdom, its massive doors radiating a sense of lost grandeur.
 --ROOM 717 END--
 --ROOM 718 START--
 The Labyrinth_: Level Five
 717,719,0,0
-   You step into the dimly lit throne room, the flickering light of torches
- casting long, dancing shadows across the walls. At the far end, seated upon a
- grotesque throne fashioned from human bones, is Malthera. Her sinister grin
- pierces the gloom, a chilling contrast to the malevolent aura that hangs heavy
- in the air.
+You step into the dimly lit throne room, the flickering light of torches casting long, dancing shadows across the walls. At the far end, seated upon a grotesque throne fashioned from human bones, is Malthera. Her sinister grin pierces the gloom, a chilling contrast to the malevolent aura that hangs heavy in the air.
 --ROOM 718 END--
 --ROOM 719 START--
 The Village Of Sylvanshade
 718,0,720,0
-   The air shimmers faintly as candles hanging along the walls spring to life,
- their flames dancing eerily without any visible source.
+The air shimmers faintly as candles hanging along the walls spring to life, their flames dancing eerily without any visible source.
 --ROOM 719 END--
 --ROOM 720 START--
 The Village Of Sylvanshade
 0,721,0,719
-   A deep rumble echoes around you as the walls begin to crumble. Stone and
- dust collapse inwards, revealing a breathtaking view of an unknown village
- nestled in the distance.
+A deep rumble echoes around you as the walls begin to crumble. Stone and dust collapse inwards, revealing a breathtaking view of an unknown village nestled in the distance.
 --ROOM 720 END--
 --ROOM 721 START--
 The Village Of Sylvanshade
 720,723,0,722
-   Towering trees and lush greenery envelop this place, as though the forest
- itself has conspired to keep this village a secret from the world.
+Towering trees and lush greenery envelop this place, as though the forest itself has conspired to keep this village a secret from the world.
 --ROOM 721 END--
 --ROOM 722 START--
 The Village Of Sylvanshade
 0,0,721,0
-   Weathered stone buildings dot the area, their aged walls standing as quiet
- witnesses to the passage of time. In the knee-high grass, a small herd of
- sheep grazes lazily, unbothered by your presence.
+Weathered stone buildings dot the area, their aged walls standing as quiet witnesses to the passage of time. In the knee-high grass, a small herd of sheep grazes lazily, unbothered by your presence.
 --ROOM 722 END--
 --ROOM 723 START--
 The Village Of Sylvanshade
 721,724,0,0
-   You step onto a quaint stone bridge, its surface cool beneath your feet.
- Below, the rushing waters of a lively brook weave a melody that echoes through
- the air.
+You step onto a quaint stone bridge, its surface cool beneath your feet. Below, the rushing waters of a lively brook weave a melody that echoes through the air.
 --ROOM 723 END--
 --ROOM 724 START--
 The Village Of Sylvanshade
 723,0,725,729
-   The trill of a bird's song carries on the breeze, light and cheerful. From
- the corner of your eye, movement catches your attention-a woman standing
- nearby, her voice rising as she calls out to you.
+The trill of a bird's song carries on the breeze, light and cheerful. From the corner of your eye, movement catches your attention-a woman standing nearby, her voice rising as she calls out to you.
 --ROOM 724 END--
 --ROOM 725 START--
 The Village Of Sylvanshade
 0,726,0,724
-   The path is flanked by crumbling wooden fences, their splintered edges worn
- down by years of weathering. Ahead, the faint outline of a holy road beckons
- you forward.
+The path is flanked by crumbling wooden fences, their splintered edges worn down by years of weathering. Ahead, the faint outline of a holy road beckons you forward.
 --ROOM 725 END--
 --ROOM 726 START--
 The Village Of Sylvanshade
 725,727,0,0
-   The flickering glow of lit torches lines the path, casting long shadows that
- dance across the dirt. In the distance, you catch sight of farmers, their
- silhouettes moving steadily as they tend to their fields.
+The flickering glow of lit torches lines the path, casting long shadows that dance across the dirt. In the distance, you catch sight of farmers, their silhouettes moving steadily as they tend to their fields.
 --ROOM 726 END--
 --ROOM 727 START--
 The Village Of Sylvanshade
 726,0,728,0
-   Your legs ache from what feels like hours of walking. Just as you consider
- stopping, a small makeshift camp comes into view, its inhabitants-an eclectic
- band of travelers-huddled around a crackling fire.
+Your legs ache from what feels like hours of walking. Just as you consider stopping, a small makeshift camp comes into view, its inhabitants-an eclectic band of travelers-huddled around a crackling fire.
 --ROOM 727 END--
 --ROOM 728 START--
 The Village Of Sylvanshade
 0,0,752,727
-   A long, meandering road stretches out before you, its surface carved deep
- into the earth. Where it might lead is a question the landscape keeps to
- itself.
+A long, meandering road stretches out before you, its surface carved deep into the earth. Where it might lead is a question the landscape keeps to itself.
 --ROOM 728 END--
 --ROOM 729 START--
 The Village Of Sylvanshade
 0,736,724,730
-   The hum of voices fills the air, a lively backdrop to your surroundings.
- Before you stands a bustling market, alive with activity and the chatter of
- villagers.
+The hum of voices fills the air, a lively backdrop to your surroundings. Before you stands a bustling market, alive with activity and the chatter of villagers.
 --ROOM 729 END--
 --ROOM 730 START--
 The Village Of Sylvanshade
 0,0,729,731
-   Merchants line the roadside, their makeshift tables adorned with handcrafted
- wares. The scent of fresh wood and spices mingles with the earthy aroma of the
- market.
+Merchants line the roadside, their makeshift tables adorned with handcrafted wares. The scent of fresh wood and spices mingles with the earthy aroma of the market.
 --ROOM 730 END--
 --ROOM 731 START--
 The Village Of Sylvanshade
 732,733,730,0
-   At the heart of the village stands a sturdy stone well, its edges worn
- smooth by generations of use. The steady drip of water from the bucket echoes
- softly.
+At the heart of the village stands a sturdy stone well, its edges worn smooth by generations of use. The steady drip of water from the bucket echoes softly.
 --ROOM 731 END--
 --ROOM 732 START--
 The Village Of Sylvanshade
 0,731,0,0
-   A small pen holds a handful of cows, their dark eyes following your
- movements. The earthy scent of hay and livestock hangs in the still air.
+A small pen holds a handful of cows, their dark eyes following your movements. The earthy scent of hay and livestock hangs in the still air.
 --ROOM 732 END--
 --ROOM 733 START--
 The Village Of Sylvanshade
 731,735,0,734
-   A narrow, twisting path snakes ahead, its well-trodden surface marked by
- countless footsteps from generations long past.
+A narrow, twisting path snakes ahead, its well-trodden surface marked by countless footsteps from generations long past.
 --ROOM 733 END--
 --ROOM 734 START--
 The Village Of Sylvanshade
 0,0,733,809
-   You stand before an opening that leads into the ruins of the village's
- ancient quarter, its aura heavy with the weight of forgotten history.
+You stand before an opening that leads into the ruins of the village's ancient quarter, its aura heavy with the weight of forgotten history.
 --ROOM 734 END--
 --ROOM 735 START--
 The Village Of Sylvanshade
 733,0,0,0
-   A dead end greets you, dominated by a boarded-up home. Brush has overgrown
- its surroundings, and an eerie silence blankets the air, sending a shiver
- through you.
+A dead end greets you, dominated by a boarded-up home. Brush has overgrown its surroundings, and an eerie silence blankets the air, sending a shiver through you.
 --ROOM 735 END--
 --ROOM 736 START--
 The Village Of Sylvanshade
 729,737,0,0
-   The worn path beneath your feet winds into a seldom-seen corner of the
- village, its secrets buried in time.
+The worn path beneath your feet winds into a seldom-seen corner of the village, its secrets buried in time.
 --ROOM 736 END--
 --ROOM 737 START--
 The Village Of Sylvanshade
 736,738,0,0
-   Weathered buildings stand as silent witnesses to lives long past, their
- empty frames echoing with the stories of those who once dwelled here.
+Weathered buildings stand as silent witnesses to lives long past, their empty frames echoing with the stories of those who once dwelled here.
 --ROOM 737 END--
 --ROOM 738 START--
 The Village Of Sylvanshade
 737,0,739,0
-   Old wooden fences, once sturdy enclosures for livestock, now yield to the
- relentless advance of grass and weeds left untamed.
+Old wooden fences, once sturdy enclosures for livestock, now yield to the relentless advance of grass and weeds left untamed.
 --ROOM 738 END--
 --ROOM 739 START--
 The Village Of Sylvanshade
 0,740,0,738
-   On the wind, faint echoes of children's laughter linger, chilling you to
- your core as it stirs memories you're certain aren't your own.
+On the wind, faint echoes of children's laughter linger, chilling you to your core as it stirs memories you're certain aren't your own.
 --ROOM 739 END--
 --ROOM 740 START--
 The Village Of Sylvanshade
 739,741,0,0
-   A cold wind brushes past, carrying with it the sense of something distant
- yet tangible-a forgotten world just out of reach.
+A cold wind brushes past, carrying with it the sense of something distant yet tangible-a forgotten world just out of reach.
 --ROOM 740 END--
 --ROOM 741 START--
 The Village Of Sylvanshade
 740,744,742,0
-   This is a place adrift, a realm seemingly forsaken and untethered from the
- world of the living.
+This is a place adrift, a realm seemingly forsaken and untethered from the world of the living.
 --ROOM 741 END--
 --ROOM 742 START--
 The Village Of Sylvanshade
 0,0,0,741
-   A weathered sign hangs ominously on a door, its words obscured but their
- warning unmistakable.
+A weathered sign hangs ominously on a door, its words obscured but their warning unmistakable.
 --ROOM 742 END--
 --ROOM 743 START--
 The Village Of Sylvanshade
 0,0,0,744
-   Before you stands the decayed husk of a barn, its doors tightly nailed shut
- as if to guard against whatever lingers within.
+Before you stands the decayed husk of a barn, its doors tightly nailed shut as if to guard against whatever lingers within.
 --ROOM 743 END--
 --ROOM 744 START--
 The Village Of Sylvanshade
 741,746,743,745
-   The crumbling remains of ancient stone structures surround you, whispering
- of an era long erased from memory.
+The crumbling remains of ancient stone structures surround you, whispering of an era long erased from memory.
 --ROOM 744 END--
 --ROOM 745 START--
 The Village Of Sylvanshade
 0,0,744,0
-   An old, unattended well sits here, nearly hidden by the encroaching blades
- of tall grass and wild wheat.
+An old, unattended well sits here, nearly hidden by the encroaching blades of tall grass and wild wheat.
 --ROOM 745 END--
 --ROOM 746 START--
 Temple Of Blessed Light
 744,747,0,0
-   Wandering deeper, you come across the weathered entrance to a crumbling
- temple, its purpose lost to time but its presence still commanding.
+Wandering deeper, you come across the weathered entrance to a crumbling temple, its purpose lost to time but its presence still commanding.
 --ROOM 746 END--
 --ROOM 747 START--
 Temple Of Blessed Light
 746,0,748,750
-   The walls here are veiled in layers of dust and cobwebs, a stark reminder of
- a bygone age.
+The walls here are veiled in layers of dust and cobwebs, a stark reminder of a bygone age.
 --ROOM 747 END--
 --ROOM 748 START--
 Temple Of Blessed Light
 0,0,749,747
-   Scattered tables and overturned chairs litter this area, as though it were
- the site of a violent clash now forgotten.
+Scattered tables and overturned chairs litter this area, as though it were the site of a violent clash now forgotten.
 --ROOM 748 END--
 --ROOM 749 START--
 Temple Of Blessed Light
 0,0,0,748
-   A storage room emerges from the shadows, packed with ancient crates whose
- contents remain a mystery.
+A storage room emerges from the shadows, packed with ancient crates whose contents remain a mystery.
 --ROOM 749 END--
 --ROOM 750 START--
 Temple Of Blessed Light
 0,751,747,0
-   A narrow, spiraling staircase descends into the unknown, beckoning you to
- venture deeper into the hidden depths of this world.
+A narrow, spiraling staircase descends into the unknown, beckoning you to venture deeper into the hidden depths of this world.
 --ROOM 750 END--
 --ROOM 751 START--
 Temple Of Blessed Light
 750,782,0,0
-   The air grows colder, your breath visible in faint, fleeting wisps that hint
- at an otherworldly chill.
+The air grows colder, your breath visible in faint, fleeting wisps that hint at an otherworldly chill.
 --ROOM 751 END--
 --ROOM 752 START--
 The Glowroot Mine
 753,0,0,728
-   You enter the old mine, where thin veins of green ore glimmer faintly, their
- glow piercing the darkness.
+You enter the old mine, where thin veins of green ore glimmer faintly, their glow piercing the darkness.
 --ROOM 752 END--
 --ROOM 753 START--
 The Glowroot Mine
 0,752,754,0
-   The faint smell of smoke lingers in the air, mingled with the distant
- clinking of pickaxes chipping at stone.
+The faint smell of smoke lingers in the air, mingled with the distant clinking of pickaxes chipping at stone.
 --ROOM 753 END--
 --ROOM 754 START--
 The Glowroot Mine
 0,0,755,753
-   Old crates line the walls, and the flicker of your lantern casts dancing
- shadows on the rocky surfaces.
+Old crates line the walls, and the flicker of your lantern casts dancing shadows on the rocky surfaces.
 --ROOM 754 END--
 --ROOM 755 START--
 The Glowroot Mine
 756,0,0,754
-   At the center of the room lies a pile of rubble and debris, the remnants of
- some long-past collapse.
+At the center of the room lies a pile of rubble and debris, the remnants of some long-past collapse.
 --ROOM 755 END--
 --ROOM 756 START--
 The Glowroot Mine
 757,755,0,0
-   A narrow path leads deeper into the mine, each step fraught with the
- unsettling sensation of impending collapse.
+A narrow path leads deeper into the mine, each step fraught with the unsettling sensation of impending collapse.
 --ROOM 756 END--
 --ROOM 757 START--
 The Glowroot Mine
 0,756,758,0
-   Dusty tables are stacked haphazardly atop one another, while chairs rest
- neatly arranged nearby, as if awaiting their purpose.
+Dusty tables are stacked haphazardly atop one another, while chairs rest neatly arranged nearby, as if awaiting their purpose.
 --ROOM 757 END--
 --ROOM 758 START--
 The Glowroot Mine
 0,0,759,757
-   A miner stands before you, pickaxe in hand, chipping methodically at the
- stone wall.
+A miner stands before you, pickaxe in hand, chipping methodically at the stone wall.
 --ROOM 758 END--
 --ROOM 759 START--
 The Glowroot Mine
 0,761,760,758
-   A cold breeze sweeps through the mine, brushing against you like the
- unwelcoming kiss of an unseen force.
+A cold breeze sweeps through the mine, brushing against you like the unwelcoming kiss of an unseen force.
 --ROOM 759 END--
 --ROOM 760 START--
 The Glowroot Mine
 0,0,0,759
-   You reach a dead end-nothing but a cold, unyielding wall of rock that seems
- to pulse with a foreboding chill.
+You reach a dead end-nothing but a cold, unyielding wall of rock that seems to pulse with a foreboding chill.
 --ROOM 760 END--
 --ROOM 761 START--
 The Glowroot Mine
 759,762,0,0
-   The rhythmic drip of water echoes from the ceiling, accompanied by the faint
- strains of a haunting melody.
+The rhythmic drip of water echoes from the ceiling, accompanied by the faint strains of a haunting melody.
 --ROOM 761 END--
 --ROOM 762 START--
 The Glowroot Mine
 761,0,763,0
-   Rusting railcars, filled with rock and soil, sit abandoned and decaying in
- the shadows.
+Rusting railcars, filled with rock and soil, sit abandoned and decaying in the shadows.
 --ROOM 762 END--
 --ROOM 763 START--
 The Glowroot Mine
 0,764,0,762
-   Each step draws you deeper into the mine's abyss, the oppressive darkness
- pressing in around you.
+Each step draws you deeper into the mine's abyss, the oppressive darkness pressing in around you.
 --ROOM 763 END--
 --ROOM 764 START--
 The Glowroot Mine
 763,769,765,0
-   A small group of miners work feverishly, their pickaxes ringing out in a
- deafening chorus against the stone.
+A small group of miners work feverishly, their pickaxes ringing out in a deafening chorus against the stone.
 --ROOM 764 END--
 --ROOM 765 START--
 The Glowroot Mine
 0,0,766,764
-   Squeezing through narrow rock walls, you emerge into a grand hall that
- stretches beyond the reach of your lantern's light.
+Squeezing through narrow rock walls, you emerge into a grand hall that stretches beyond the reach of your lantern's light.
 --ROOM 765 END--
 --ROOM 766 START--
 The Glowroot Mine
 0,767,0,765
-   The walls here are intricately carved, resembling a long-forgotten place of
- worship. A towering statue looms before you, its gaze unyielding in the
- flickering torchlight.
+The walls here are intricately carved, resembling a long-forgotten place of worship. A towering statue looms before you, its gaze unyielding in the flickering torchlight.
 --ROOM 766 END--
 --ROOM 767 START--
 The Glowroot Mine
 766,768,0,0
-   This place lies in utter ruin-broken tables and tattered cloth strewn about
- like the remnants of a chaotic past.
+This place lies in utter ruin-broken tables and tattered cloth strewn about like the remnants of a chaotic past.
 --ROOM 767 END--
 --ROOM 768 START--
 The Glowroot Mine
 767,0,0,0
-   In the corner, a young priestess pores over ancient texts at a small, worn
- desk, her expression one of focused determination.
+In the corner, a young priestess pores over ancient texts at a small, worn desk, her expression one of focused determination.
 --ROOM 768 END--
 --ROOM 769 START--
 The Glowroot Mine
 764,0,0,770
-   Turning a corner, you catch sight of shadows dancing against the walls
- workers immersed in their toils.
+Turning a corner, you catch sight of shadows dancing against the walls workers immersed in their toils.
 --ROOM 769 END--
 --ROOM 770 START--
 The Glowroot Mine
 0,771,769,0
-   Miners toil around a railcar filled with green ore, the fruits of their
- labor nearly ready for the surface.
+Miners toil around a railcar filled with green ore, the fruits of their labor nearly ready for the surface.
 --ROOM 770 END--
 --ROOM 771 START--
 The Glowroot Mine
 770,772,0,0
-   The stone walls bear the scars of countless pickaxes, their marks telling a
- story of relentless effort.
+The stone walls bear the scars of countless pickaxes, their marks telling a story of relentless effort.
 --ROOM 771 END--
 --ROOM 772 START--
 The Glowroot Mine
 771,773,0,0
-   The air thickens and grows warm, the temperature rising ominously the longer
- you linger.
+The air thickens and grows warm, the temperature rising ominously the longer you linger.
 --ROOM 772 END--
 --ROOM 773 START--
 The Glowroot Mine
 772,776,774,775
-   The ground trembles beneath your feet, and in an instant, you find yourself
- utterly alone.
+The ground trembles beneath your feet, and in an instant, you find yourself utterly alone.
 --ROOM 773 END--
 --ROOM 774 START--
 The Glowroot Mine
 0,0,0,773
-   A small room appears, its makeshift beds arranged neatly, each one a
- fleeting promise of rest for weary workers.
+A small room appears, its makeshift beds arranged neatly, each one a fleeting promise of rest for weary workers.
 --ROOM 774 END--
 --ROOM 775 START--
 The Glowroot Mine
 0,0,773,0
-   A storage room lies ahead, stacked high with crates brimming with supplies
- for the miners' unyielding labor.
+A storage room lies ahead, stacked high with crates brimming with supplies for the miners' unyielding labor.
 --ROOM 775 END--
 --ROOM 776 START--
 The Glowroot Mine
 773,777,0,0
-   The mine's depths stretch endlessly before you, each step drawing you
- further into the unknown.
+The mine's depths stretch endlessly before you, each step drawing you further into the unknown.
 --ROOM 776 END--
 --ROOM 777 START--
 The Glowroot Mine
 776,778,0,0
-   The deeper you delve, the more alone you feel, as if the mine itself seeks
- to isolate you from the world above.
+The deeper you delve, the more alone you feel, as if the mine itself seeks to isolate you from the world above.
 --ROOM 777 END--
 --ROOM 778 START--
 The Glowroot Mine
 777,0,0,779
-   Echoes of movement resound through the cold stone walls, their source
- uncertain and unnerving.
+Echoes of movement resound through the cold stone walls, their source uncertain and unnerving.
 --ROOM 778 END--
 --ROOM 779 START--
 The Glowroot Mine
 0,780,778,0
-   You stand before a precarious wooden platform spanning a seemingly
- bottomless chasm.
+You stand before a precarious wooden platform spanning a seemingly bottomless chasm.
 --ROOM 779 END--
 --ROOM 780 START--
 The Glowroot Mine
 779,0,0,781
-   The platform creaks and sways beneath your feet, each step accompanied by
- the unsettling sound of splitting wood.
+The platform creaks and sways beneath your feet, each step accompanied by the unsettling sound of splitting wood.
 --ROOM 780 END--
 --ROOM 781 START--
 The Glowroot Mine
 0,829,780,0
-   Reaching the far side, relief washes over you as solid ground once again
- supports your weight.
+Reaching the far side, relief washes over you as solid ground once again supports your weight.
 --ROOM 781 END--
 --ROOM 782 START--
 The Temple Of Knowledge
 751,784,0,783
-   A sanctum where knowledge ascends to the highest plane of existence,
- radiating a sense of reverence and wonder.
+A sanctum where knowledge ascends to the highest plane of existence, radiating a sense of reverence and wonder.
 --ROOM 782 END--
 --ROOM 783 START--
 The Temple Of Knowledge
 0,0,782,0
-   Towering bookcases hold the breadth of human understanding, a world of
- wisdom waiting to be explored.
+Towering bookcases hold the breadth of human understanding, a world of wisdom waiting to be explored.
 --ROOM 783 END--
 --ROOM 784 START--
 The Temple Of Knowledge
 782,785,0,0
-   The walls, ancient and enigmatic, bear the marks of a forgotten era.
- Everything about this chamber exudes an uncanny and alien allure.
+The walls, ancient and enigmatic, bear the marks of a forgotten era. Everything about this chamber exudes an uncanny and alien allure.
 --ROOM 784 END--
 --ROOM 785 START--
 The Temple Of Knowledge
 784,0,786,0
-   Piles of aged tomes are scattered across the massive tables, as if their
- readers fled in haste, leaving secrets untold.
+Piles of aged tomes are scattered across the massive tables, as if their readers fled in haste, leaving secrets untold.
 --ROOM 785 END--
 --ROOM 786 START--
 The Temple Of Knowledge
 0,789,787,785
-   This space feels recently forsaken, the echoes of its former occupants still
- lingering in the air.
+This space feels recently forsaken, the echoes of its former occupants still lingering in the air.
 --ROOM 786 END--
 --ROOM 787 START--
 The Temple Of Knowledge
 788,0,0,786
-   Dust-laden curtains obscure the windows, their silence oppressive. With each
- step, the sensation of unseen eyes grows stronger.
+Dust-laden curtains obscure the windows, their silence oppressive. With each step, the sensation of unseen eyes grows stronger.
 --ROOM 787 END--
 --ROOM 788 START--
 The Temple Of Knowledge
 0,787,0,0
-   An endless labyrinth of bookcases stretches before you, each shelf brimming
- with volumes that whisper untold stories.
+An endless labyrinth of bookcases stretches before you, each shelf brimming with volumes that whisper untold stories.
 --ROOM 788 END--
 --ROOM 789 START--
 The Temple Of Knowledge
 786,790,0,0
-   The silence is so profound that the rhythm of your heartbeat becomes the
-  only sound, echoing in the stillness.
+The silence is so profound that the rhythm of your heartbeat becomes the only sound, echoing in the stillness.
 --ROOM 789 END--
 --ROOM 790 START--
 The Temple Of Knowledge
 789,792,0,791
-   Darkness envelops the space, and just beyond your vision, fleeting shapes
- dart through the shadows.
+Darkness envelops the space, and just beyond your vision, fleeting shapes dart through the shadows.
 --ROOM 790 END--
 --ROOM 791 START--
 The Temple Of Knowledge
 0,0,790,0
-   A dead end. Towering bookcases rise like barriers, blocking your way
- forward.
+A dead end. Towering bookcases rise like barriers, blocking your way forward.
 --ROOM 791 END--
 --ROOM 792 START--
 The Temple Of Knowledge
 790,0,793,0
-   Suddenly, candles ignite in unison, their flames casting a flickering glow
- as the room begins to swirl and come alive with arcane energy.
+Suddenly, candles ignite in unison, their flames casting a flickering glow as the room begins to swirl and come alive with arcane energy.
 --ROOM 792 END--
 --ROOM 793 START--
 The Temple Of Knowledge
 0,794,0,792
-   Phantom echoes fill the air as if you've stepped into another era,
- surrounded by the restless souls of the past.
+Phantom echoes fill the air as if you've stepped into another era, surrounded by the restless souls of the past.
 --ROOM 793 END--
 --ROOM 794 START--
 The Temple Of Knowledge
 793,795,0,0
-   You stand before an immense archive, its endless corridors stretching into
- the void, defying the limits of perception.
+You stand before an immense archive, its endless corridors stretching into the void, defying the limits of perception.
 --ROOM 794 END--
 --ROOM 795 START--
 The Temple Of Knowledge
 794,0,0,796
-   The room shifts and reveals a hidden staircase, its narrow steps descending
- into a foreboding abyss.
+The room shifts and reveals a hidden staircase, its narrow steps descending into a foreboding abyss.
 --ROOM 795 END--
 --ROOM 796 START--
 The Temple Of Knowledge
 0,797,795,0
-   With every step, the air grows colder, and the temperature seems to sink
- ever so slightly, as if the world itself is exhaling.
+With every step, the air grows colder, and the temperature seems to sink ever so slightly, as if the world itself is exhaling.
 --ROOM 796 END--
 --ROOM 797 START--
 The Temple Of Knowledge
 796,798,0,0
-   You stand before a towering mechanical behemoth, its massive joints hissing
- and releasing bursts of steam, a machine both magnificent and menacing.
+You stand before a towering mechanical behemoth, its massive joints hissing and releasing bursts of steam, a machine both magnificent and menacing.
 --ROOM 797 END--
 --ROOM 798 START--
 The Temple Of Knowledge
 797,799,0,0
-   This once-great hall stretches before you, its walls cloaked in a grimy
- layer of soot. The air is thick with decay, and ruin lies in every direction.
+This once-great hall stretches before you, its walls cloaked in a grimy layer of soot. The air is thick with decay, and ruin lies in every direction.
 --ROOM 798 END--
 --ROOM 799 START--
 The Temple Of Knowledge
 798,0,800,802
-   A harrowing cry echoes from the distance, carrying a weight that sends
- shivers down your spine and chills deep into your soul.
+A harrowing cry echoes from the distance, carrying a weight that sends shivers down your spine and chills deep into your soul.
 --ROOM 799 END--
 --ROOM 800 START--
 The Temple Of Knowledge
 801,0,0,799
-   A ghostly green light shimmers in the gloom, casting an eerie glow that
- almost seems to greet you with an unsettling politeness.
+A ghostly green light shimmers in the gloom, casting an eerie glow that almost seems to greet you with an unsettling politeness.
 --ROOM 800 END--
 --ROOM 801 START--
 The Temple Of Knowledge
 0,800,0,0
-   A single portrait dominates the wall, its subject gazing back at you. The
- room offers no other paths, trapping you within its silent confines.
+A single portrait dominates the wall, its subject gazing back at you. The room offers no other paths, trapping you within its silent confines.
 --ROOM 801 END--
 --ROOM 802 START--
 The Temple Of Knowledge
 0,807,799,803
-   This place saps your strength with every passing moment, leaving you feeling
- hollow, fragile, and utterly drained of life.
+This place saps your strength with every passing moment, leaving you feeling hollow, fragile, and utterly drained of life.
 --ROOM 802 END--
 --ROOM 803 START--
 The Temple Of Knowledge
 806,0,802,804
-   You stand at the entrance to a majestic hall, its walls adorned with
- gleaming gold and studded with priceless emeralds that shimmer in the dim
- light.
+You stand at the entrance to a majestic hall, its walls adorned with gleaming gold and studded with priceless emeralds that shimmer in the dim light.
 --ROOM 803 END--
 --ROOM 804 START--
 The Temple Of Knowledge
 805,0,803,0
-   The faint, ethereal form of the Keeper of Knowledge materializes before you,
- its presence both ancient and commanding.
+The faint, ethereal form of the Keeper of Knowledge materializes before you, its presence both ancient and commanding.
 --ROOM 804 END--
 --ROOM 805 START--
 The Temple Of Knowledge
 0,804,806,0
-   In the center of the room stands a platform radiating a strange, hypnotic
- glow, its allure impossible to ignore.
+In the center of the room stands a platform radiating a strange, hypnotic glow, its allure impossible to ignore.
 --ROOM 805 END--
 --ROOM 806 START--
 The Temple Of Knowledge
 0,803,0,805
-   Rows of imposing statues line the walls, their cold gazes unyielding. Tables
- and chairs are scattered throughout, remnants of a once-lively space.
+Rows of imposing statues line the walls, their cold gazes unyielding. Tables and chairs are scattered throughout, remnants of a once-lively space.
 --ROOM 806 END--
 --ROOM 807 START--
 The Temple Of Knowledge
 802,808,0,0
-   The walls seem to close in, shrinking the world around you until you find
- yourself confined in a room scarcely wider than a few feet.
+The walls seem to close in, shrinking the world around you until you find yourself confined in a room scarcely wider than a few feet.
 --ROOM 807 END--
 --ROOM 808 START--
 The Temple Of Knowledge
 807,868,0,0
-   A sudden burst of brilliant light consumes your vision. When it fades, you
- find yourself standing in a serene field, transported to an entirely new
- place.
+A sudden burst of brilliant light consumes your vision. When it fades, you find yourself standing in a serene field, transported to an entirely new place.
 --ROOM 808 END--
 --ROOM 809 START--
 Ashenbark Grove
 0,0,734,810
-   You are standing in the middle of a serene field. The crystal blue sky
- stretches endlessly above, and the warm rays of the Sun bathe you in a
- comforting glow. A profound sense of peace settles over you.
+You are standing in the middle of a serene field. The crystal blue sky stretches endlessly above, and the warm rays of the Sun bathe you in a comforting glow. A profound sense of peace settles over you.
 --ROOM 809 END--
 --ROOM 810 START--
 Ashenbark Grove
 811,0,809,0
-   Faint birdsong drifts through the air, a wistful reminder of the world that
- exists beyond this place.
+Faint birdsong drifts through the air, a wistful reminder of the world that exists beyond this place.
 --ROOM 810 END--
 --ROOM 811 START--
 Ashenbark Grove
 812,810,0,0
-   The world around you feels strangely out of place. Yet, a faint glimmer of
- hope stirs within you, whispering that perhaps you've returned to the surface
- world.
+The world around you feels strangely out of place. Yet, a faint glimmer of hope stirs within you, whispering that perhaps you've returned to the surface world.
 --ROOM 811 END--
 --ROOM 812 START--
 Ashenbark Grove
 0,811,0,813
-   A gentle, warm breeze brushes past, momentarily silencing the world around
- you. All is calm, as if nature itself is holding its breath.
+A gentle, warm breeze brushes past, momentarily silencing the world around you. All is calm, as if nature itself is holding its breath.
 --ROOM 812 END--
 --ROOM 813 START--
 Ashenbark Grove
 0,0,812,814
-   You tread a narrow, uneven path. Stones embedded in the dirt make your
- footing precarious, but you press on.
+You tread a narrow, uneven path. Stones embedded in the dirt make your footing precarious, but you press on.
 --ROOM 813 END--
 --ROOM 814 START--
 Ashenbark Grove
 0,820,813,0
-   A towering wall of trees looms before you. Above, the fleeting shadow of a
- hawk darts across the land, a fleeting specter of the skies.
+A towering wall of trees looms before you. Above, the fleeting shadow of a hawk darts across the land, a fleeting specter of the skies.
 --ROOM 814 END--
 --ROOM 815 START--
 Ashenbark Grove
 821,816,0,0
-   The world is eerily still. For one fleeting moment, you feel a profound
- tranquility, as though you've stumbled upon a place untouched by time.
+The world is eerily still. For one fleeting moment, you feel a profound tranquility, as though you've stumbled upon a place untouched by time.
 --ROOM 815 END--
 --ROOM 816 START--
 Ashenbark Grove
 815,817,0,0
-   Here, amidst the wild, you feel a strange freedom-a release from the
- confines of the underworld. Yet, the question lingers: where are you truly?
+Here, amidst the wild, you feel a strange freedom-a release from the confines of the underworld. Yet, the question lingers: where are you truly?
 --ROOM 816 END--
 --ROOM 817 START--
 Ashenbark Grove
 816,0,818,0
-   A rustling sound breaks the stillness. Something stirs within the brush, its
- presence elusive yet undeniable.
+A rustling sound breaks the stillness. Something stirs within the brush, its presence elusive yet undeniable.
 --ROOM 817 END--
 --ROOM 818 START--
 Ashenbark Grove
 820,819,0,817
-   A rabbit darts across your path, a blur of movement before vanishing into
- the safety of the brush. It leaves only silence in its wake.
+A rabbit darts across your path, a blur of movement before vanishing into the safety of the brush. It leaves only silence in its wake.
 --ROOM 818 END--
 --ROOM 819 START--
 Ashenbark Grove
 818,0,0,0
-   Before you stretches a wide clearing, offering a breathtaking view of an
- open, unending expanse. The horizon calls to you with a quiet promise of
- possibility.
+Before you stretches a wide clearing, offering a breathtaking view of an open, unending expanse. The horizon calls to you with a quiet promise of possibility.
 --ROOM 819 END--
 --ROOM 820 START--
 Ashenbark Grove
 814,818,0,0
-   The crisp scent of fresh air fills your lungs, invigorating your spirit. For
- a moment, the vast unknown holds no fear-only wonder.
+The crisp scent of fresh air fills your lungs, invigorating your spirit. For a moment, the vast unknown holds no fear-only wonder.
 --ROOM 820 END--
 --ROOM 821 START--
 Ashenbark Grove
 822,815,0,0
-   The path beneath your feet begins to fade, its edges swallowed by the land.
- Soon, you find yourself standing at the edge of a vast, open clearing.
+The path beneath your feet begins to fade, its edges swallowed by the land. Soon, you find yourself standing at the edge of a vast, open clearing.
 --ROOM 821 END--
 --ROOM 822 START--
 Ashenbark Grove
 0,821,823,0
-   The sound of grass crunching underfoot accompanies your journey, each step
- carrying you deeper into the untamed unknown.
+The sound of grass crunching underfoot accompanies your journey, each step carrying you deeper into the untamed unknown.
 --ROOM 822 END--
 --ROOM 823 START--
 Ashenbark Grove
 824,0,0,822
-   As the Sun dips below the horizon, painting the sky with hues of amber and
- violet, the rhythmic beat of a distant drum begins to echo. It's a sound that
- stirs something primal within you.
+As the Sun dips below the horizon, painting the sky with hues of amber and violet, the rhythmic beat of a distant drum begins to echo. It's a sound that stirs something primal within you.
 --ROOM 823 END--
 --ROOM 824 START--
 Ashenbark Grove
 825,823,0,0
-   Night blankets the land in shadows. You make a bed amidst the tall grass and
- lie down, seeking a few precious moments of rest beneath the endless sky.
+Night blankets the land in shadows. You make a bed amidst the tall grass and lie down, seeking a few precious moments of rest beneath the endless sky.
 --ROOM 824 END--
 --ROOM 825 START--
 Ashenbark Grove
 828,824,826,0
-   In the distance, something moves. A figure-or perhaps a shadow-stirs within
- the grass, its form flickering just beyond recognition.
+In the distance, something moves. A figure-or perhaps a shadow-stirs within the grass, its form flickering just beyond recognition.
 --ROOM 825 END--
 --ROOM 826 START--
 Ashenbark Grove
 827,0,0,825
-   You are surrounded by an endless sea of knee-high grass, swaying gently in
- the breeze. The expanse feels both boundless and isolating.
+You are surrounded by an endless sea of knee-high grass, swaying gently in the breeze. The expanse feels both boundless and isolating.
 --ROOM 826 END--
 --ROOM 827 START--
 Ashenbark Grove
 0,826,0,828
-   A wave of peace washes over you, calming your thoughts. Yet, an unshakable
- sensation creeps in-the feeling that unseen eyes are upon you.
+A wave of peace washes over you, calming your thoughts. Yet, an unshakable sensation creeps in-the feeling that unseen eyes are upon you.
 --ROOM 827 END--
 --ROOM 828 START--
 Ashenbark Grove
 0,825,827,0
-   From somewhere unseen, a woman's voice calls out. Her tone is soft yet
- urgent, imploring you to leave this place before it's too late.
+From somewhere unseen, a woman's voice calls out. Her tone is soft yet urgent, imploring you to leave this place before it's too late.
 --ROOM 828 END--
 --ROOM 829 START--
 The Glowroot Mine
 781,830,0,0
-   The temperature plunges as you stand before a crude wall of wood and stone.
- A makeshift door, weathered and uneven, blocks your path, exuding an air of
- foreboding.
+The temperature plunges as you stand before a crude wall of wood and stone. A makeshift door, weathered and uneven, blocks your path, exuding an air of foreboding.
 --ROOM 829 END--
 --ROOM 830 START--
 The Glowroot Mine
 829,0,831,0
-   A massive fire roars at the center of the room, its blinding light searing
- your vision and casting wild, dancing shadows across the walls.
+A massive fire roars at the center of the room, its blinding light searing your vision and casting wild, dancing shadows across the walls.
 --ROOM 830 END--
 --ROOM 831 START--
 The Glowroot Mine
 0,833,832,830
-   Your footsteps echo endlessly, reverberating through the desolate emptiness
- of this cavernous space.
+Your footsteps echo endlessly, reverberating through the desolate emptiness of this cavernous space.
 --ROOM 831 END--
 --ROOM 832 START--
 The Glowroot Mine
 0,0,0,831
-   A dead end. Stacks of crates and scattered supplies fill the area, remnants
- of those who once sought refuge or sustenance here.
+A dead end. Stacks of crates and scattered supplies fill the area, remnants of those who once sought refuge or sustenance here.
 --ROOM 832 END--
 --ROOM 833 START--
 The Glowroot Mine
 831,834,0,0
-   Jagged rocks protrude from the walls like teeth as you venture deeper into
- the oppressive darkness of this abyss.
+Jagged rocks protrude from the walls like teeth as you venture deeper into the oppressive darkness of this abyss.
 --ROOM 833 END--
 --ROOM 834 START--
 The Glowroot Mine
 833,0,835,0
-   Flickering candles scatter their faint glow across the chamber. At the
- center, a stone slab resembling a table holds what seems to be a lifeless
- body, draped in shadows.
+Flickering candles scatter their faint glow across the chamber. At the center, a stone slab resembling a table holds what seems to be a lifeless body, draped in shadows.
 --ROOM 834 END--
 --ROOM 835 START--
 The Glowroot Mine
 0,836,0,834
-   Faint murmurs of conversation drift through the air. You pause, straining to
- discern the words, their source tantalizingly close yet elusive.
+Faint murmurs of conversation drift through the air. You pause, straining to discern the words, their source tantalizingly close yet elusive.
 --ROOM 835 END--
 --ROOM 836 START--
 The Glowroot Mine
 835,845,837,0
-   The rhythmic sounds of someone working break the stillness. Metal scraping
- against stone suggests an urgent search, though the purpose remains unknown.
+The rhythmic sounds of someone working break the stillness. Metal scraping against stone suggests an urgent search, though the purpose remains unknown.
 --ROOM 836 END--
 --ROOM 837 START--
 The Glowroot Mine
 0,0,838,836
-   A rancid stench of death and decay permeates the air, assaulting your senses
- and turning your stomach.
+A rancid stench of death and decay permeates the air, assaulting your senses and turning your stomach.
 --ROOM 837 END--
 --ROOM 838 START--
 The Glowroot Mine
 0,839,841,837
-   Before you yawns a gaping hole in the ground, an endless void that seems to
- stretch into eternity, swallowing all light.
+Before you yawns a gaping hole in the ground, an endless void that seems to stretch into eternity, swallowing all light.
 --ROOM 838 END--
 --ROOM 839 START--
 The Glowroot Mine
 838,840,0,0
-   Torches affixed to the walls flicker weakly, casting unsettling shadows on
- the floor, which is marred by dark, blood-like stains.
+Torches affixed to the walls flicker weakly, casting unsettling shadows on the floor, which is marred by dark, blood-like stains.
 --ROOM 839 END--
 --ROOM 840 START--
 The Glowroot Mine
 839,0,0,0
-   Carved into the rock before you is a crude bed, its surface draped with a
- tattered blanket that hints at long-abandoned rest.
+Carved into the rock before you is a crude bed, its surface draped with a tattered blanket that hints at long-abandoned rest.
 --ROOM 840 END--
 --ROOM 841 START--
 The Glowroot Mine
 842,0,0,838
-   Voices carry from up ahead, their hushed tones indistinct but undeniably
- human.
+Voices carry from up ahead, their hushed tones indistinct but undeniably human.
 --ROOM 841 END--
 --ROOM 842 START--
 The Glowroot Mine
 0,841,843,0
-   A staircase spirals upward, leading you into what appears to be a makeshift
- sanctuary of worship, its solemn air heavy with unspoken prayers.
+A staircase spirals upward, leading you into what appears to be a makeshift sanctuary of worship, its solemn air heavy with unspoken prayers.
 --ROOM 842 END--
 --ROOM 843 START--
 The Glowroot Mine
 844,0,0,842
-   Standing before you, arms outstretched, is a cloaked figure-an emissary of
- the dead. The flickering torchlight casts eerie patterns, hinting at the
- dreadful truths awaiting you.
+Standing before you, arms outstretched, is a cloaked figure-an emissary of the dead. The flickering torchlight casts eerie patterns, hinting at the dreadful truths awaiting you.
 --ROOM 843 END--
 --ROOM 844 START--
 The Glowroot Mine
 0,843,0,0
-   Several ancient coffins lie haphazardly stacked, their lids askew, their
- contents long plundered by time or greed.
+Several ancient coffins lie haphazardly stacked, their lids askew, their contents long plundered by time or greed.
 --ROOM 844 END--
 --ROOM 845 START--
 The Glowroot Mine
 836,0,0,846
-   A narrow tunnel winds through the earth, delivering you to a wooden gate.
- Beyond it lies a pit of despair, beckoning you forward.
+A narrow tunnel winds through the earth, delivering you to a wooden gate. Beyond it lies a pit of despair, beckoning you forward.
 --ROOM 845 END--
 --ROOM 846 START--
 The Glowroot Mine
 0,847,845,0
-   Hay covers the ground in uneven patches, perhaps an attempt to lend comfort
- or to soak up the inevitable spills of blood and grime.
+Hay covers the ground in uneven patches, perhaps an attempt to lend comfort or to soak up the inevitable spills of blood and grime.
 --ROOM 846 END--
 --ROOM 847 START--
 The Glowroot Mine
 846,850,0,848
-   Everything about this chamber feels otherworldly. Rusted chains dangle
- ominously from the walls, and the hay on the floor appears freshly spread, as
- if in preparation for some grim purpose.
+Everything about this chamber feels otherworldly. Rusted chains dangle ominously from the walls, and the hay on the floor appears freshly spread, as if in preparation for some grim purpose.
 --ROOM 847 END--
 --ROOM 848 START--
 The Glowroot Mine
 0,849,847,0
-   Silence reigns here, broken only by the steady drip of water on cold rock.
- The lifeless walls of the mine close in around you.
+Silence reigns here, broken only by the steady drip of water on cold rock. The lifeless walls of the mine close in around you.
 --ROOM 848 END--
 --ROOM 849 START--
 The Glowroot Mine
 848,0,850,0
-   Tables caked with dried blood dominate the room. The stench of rot and decay
- mingles with the acrid scent of old, unwashed dishes scattered carelessly
- about.
+Tables caked with dried blood dominate the room. The stench of rot and decay mingles with the acrid scent of old, unwashed dishes scattered carelessly about.
 --ROOM 849 END--
 --ROOM 850 START--
 The Glowroot Mine
 847,851,0,849
-   You collide with a cloaked figure who recoils, startled by your presence in
- this hallowed and forsaken place.
+You collide with a cloaked figure who recoils, startled by your presence in this hallowed and forsaken place.
 --ROOM 850 END--
 --ROOM 851 START--
 The Glowroot Mine
 850,852,0,0
-   You stand at the threshold of a world unlike your own. Towering pillars
- reach upward to support the ceiling, and the faint strains of ethereal music
- drift through the air, beckoning you forward.
+You stand at the threshold of a world unlike your own. Towering pillars reach upward to support the ceiling, and the faint strains of ethereal music drift through the air, beckoning you forward.
 --ROOM 851 END--
 --ROOM 852 START--
 The Glowroot Mine
 851,0,853,0
-   The walls are covered in strange, erratic writings, their chaotic patterns
- suggesting the hand of a mad or tormented mind.
+The walls are covered in strange, erratic writings, their chaotic patterns suggesting the hand of a mad or tormented mind.
 --ROOM 852 END--
 --ROOM 853 START--
 The Glowroot Mine
 0,857,854,852
-   A massive statue looms above you, its features so lifelike that, for a
- moment, you feel as though it might move at any second.
+A massive statue looms above you, its features so lifelike that, for a moment, you feel as though it might move at any second.
 --ROOM 853 END--
 --ROOM 854 START--
 The Glowroot Mine
 855,0,0,853
-   A narrow staircase spirals down into the deep abyss. The oppressive darkness
- is accompanied by the unsettling sensation of unseen eyes watching your every
- step.
+A narrow staircase spirals down into the deep abyss. The oppressive darkness is accompanied by the unsettling sensation of unseen eyes watching your every step.
 --ROOM 854 END--
 --ROOM 855 START--
 The Glowroot Mine
 0,854,856,0
-   From the shadows above, a man-sized spider dangles ominously, its many eyes
- glinting as it watches you with predatory intent.
+From the shadows above, a man-sized spider dangles ominously, its many eyes glinting as it watches you with predatory intent.
 --ROOM 855 END--
 --ROOM 856 START--
 The Glowroot Mine
 0,0,0,855
-   The passage comes to an abrupt end, leaving you facing a solid wall of
- unyielding rock. There is nowhere else to go.
+The passage comes to an abrupt end, leaving you facing a solid wall of unyielding rock. There is nowhere else to go.
 --ROOM 856 END--
 --ROOM 857 START--
 The Glowroot Mine
 853,858,0,0
-   After wandering aimlessly, you stumble upon a platform suspended from the
- rocky ceiling. The moment you step onto it, it begins to creak and move,
- carrying you into an endless sea of darkness.
+After wandering aimlessly, you stumble upon a platform suspended from the rocky ceiling. The moment you step onto it, it begins to creak and move, carrying you into an endless sea of darkness.
 --ROOM 857 END--
 --ROOM 858 START--
 The Glowroot Mine
 857,859,0,0
-   A chorus of shrill screams echoes through the cavern as bats swarm around
- the moving platform. A few break away, diving perilously close to you.
+A chorus of shrill screams echoes through the cavern as bats swarm around the moving platform. A few break away, diving perilously close to you.
 --ROOM 858 END--
 --ROOM 859 START--
 The Glowroot Mine
 858,0,860,0
-   The ground beneath the platform disappears into the void as the structure
- sways and jolts precariously, threatening to toss you into the darkness below.
+The ground beneath the platform disappears into the void as the structure sways and jolts precariously, threatening to toss you into the darkness below.
 --ROOM 859 END--
 --ROOM 860 START--
 The Glowroot Mine
 0,862,861,859
-   The platform lurches to a halt with a violent jolt, throwing you forward and
- leaving you momentarily unsteady.
+The platform lurches to a halt with a violent jolt, throwing you forward and leaving you momentarily unsteady.
 --ROOM 860 END--
 --ROOM 861 START--
 The Glowroot Mine
 0,0,0,860
-   You cautiously descend a narrow flight of stairs, only to find yourself at a
- dead end, the way forward blocked by an imposing wall of stone.
+You cautiously descend a narrow flight of stairs, only to find yourself at a dead end, the way forward blocked by an imposing wall of stone.
 --ROOM 861 END--
 --ROOM 862 START--
 The Glowroot Mine
 860,863,0,0
-   Venturing deeper into the earth, you arrive at the edge of a gently flowing
- stream. Its surface shimmers faintly in the dim light, tantalizingly close to
- your feet.
+Venturing deeper into the earth, you arrive at the edge of a gently flowing stream. Its surface shimmers faintly in the dim light, tantalizingly close to your feet.
 --ROOM 862 END--
 --ROOM 863 START--
 The Glowroot Mine
 862,0,864,0
-   Shadows flit about the space around you. Ghostly figures walk in aimless
- silence, their hollow expressions oblivious to your presence.
+Shadows flit about the space around you. Ghostly figures walk in aimless silence, their hollow expressions oblivious to your presence.
 --ROOM 863 END--
 --ROOM 864 START--
 The Glowroot Mine
 0,0,865,863
-   You find yourself standing before what appears to be the entrance to a
- modest dwelling. Its weathered exterior suggests a long history hidden within.
+You find yourself standing before what appears to be the entrance to a modest dwelling. Its weathered exterior suggests a long history hidden within.
 --ROOM 864 END--
 --ROOM 865 START--
 The Glowroot Mine
 0,0,866,864
-   Inside, a family sits around a simple table, sharing a loaf of bread. Their
- eyes never meet yours, as though you are invisible to them.
+Inside, a family sits around a simple table, sharing a loaf of bread. Their eyes never meet yours, as though you are invisible to them.
 --ROOM 865 END--
 --ROOM 866 START--
 The Glowroot Mine
 867,0,0,865
-   The darkness presses in from all sides, and a cacophony of whispering voices
- surrounds you, their words indistinct but undeniably eerie.
+The darkness presses in from all sides, and a cacophony of whispering voices surrounds you, their words indistinct but undeniably eerie.
 --ROOM 866 END--
 --ROOM 867 START--
 The Glowroot Mine
 0,866,0,0
-   A figure steps into view, their face adorned with a warm, welcoming smile.
- The kindly wizard regards you with a twinkle of mischief in their eye.
+A figure steps into view, their face adorned with a warm, welcoming smile. The kindly wizard regards you with a twinkle of mischief in their eye.
 --ROOM 867 END--
 --ROOM 868 START--
 The Temple Of Knowledge_: Level Two
 808,869,0,0
-   The faint aroma of burning incense wafts through the air, enveloping you in
- a sense of peace and calm.
+The faint aroma of burning incense wafts through the air, enveloping you in a sense of peace and calm.
 --ROOM 868 END--
 --ROOM 869 START--
 The Temple Of Knowledge_: Level Two
 This ancient place of worship, once a sanctuary of knowledge and faith, holds
- echoes of beliefs long forgotten by the surface world.
-868,0,0,870
+echoes of beliefs long forgotten by the surface world. 868,0,0,870
 --ROOM 869 END--
 --ROOM 870 START--
 The Temple Of Knowledge_: Level Two
 0,871,869,882
-   A thick layer of dust carpets the floors, while cobwebs cling stubbornly to
- the crumbling walls.
+A thick layer of dust carpets the floors, while cobwebs cling stubbornly to the crumbling walls.
 --ROOM 870 END--
 --ROOM 871 START--
 The Temple Of Knowledge_: Level Two
 870,872,0,0
-   As you take in your surroundings, you wonder just how many centuries this
- place has stood abandoned.
+As you take in your surroundings, you wonder just how many centuries this place has stood abandoned.
 --ROOM 871 END--
 --ROOM 872 START--
 The Temple Of Knowledge_: Level Two
 871,874,873,0
-   A narrow, winding walkway twists and turns before opening into a modest
- chamber.
+A narrow, winding walkway twists and turns before opening into a modest chamber.
 --ROOM 872 END--
 --ROOM 873 START--
 The Temple Of Knowledge_: Level Two
 0,0,0,872
-   A boarded-up hall greets you. Deep scratch marks etched into the wood
- suggest a desperate chase by something unholy.
+A boarded-up hall greets you. Deep scratch marks etched into the wood suggest a desperate chase by something unholy.
 --ROOM 873 END--
 --ROOM 874 START--
 The Temple Of Knowledge_: Level Two
 872,0,0,875
-   This desolate place feels like a tomb of a dead world. The torches lining
- the walls have long since burned out, leaving only darkness behind.
+This desolate place feels like a tomb of a dead world. The torches lining the walls have long since burned out, leaving only darkness behind.
 --ROOM 874 END--
 --ROOM 875 START--
 The Temple Of Knowledge_: Level Two
 0,0,874,876
-   You stand before bare, empty walls. Whatever relics this place once held
- were stolen or lost long ago.
+You stand before bare, empty walls. Whatever relics this place once held were stolen or lost long ago.
 --ROOM 875 END--
 --ROOM 876 START--
 The Temple Of Knowledge_: Level Two
 0,883,875,877
-   The distant sound of rushing water echoes faintly, a subtle reminder of the
- world beyond these walls.
+The distant sound of rushing water echoes faintly, a subtle reminder of the world beyond these walls.
 --ROOM 876 END--
 --ROOM 877 START--
 The Temple Of Knowledge_: Level Two
 878,0,876,0
-   The hallway leads to a room where tables and chairs are neatly stacked, an
- eerie sense of order in an otherwise chaotic world.
+The hallway leads to a room where tables and chairs are neatly stacked, an eerie sense of order in an otherwise chaotic world.
 --ROOM 877 END--
 --ROOM 878 START--
 The Temple Of Knowledge_: Level Two
 879,877,0,0
-   The faint sound of hissing drifts through the air, sending a chill down your
- spine.
+The faint sound of hissing drifts through the air, sending a chill down your spine.
 --ROOM 878 END--
 --ROOM 879 START--
 The Temple Of Knowledge_: Level Two
 0,878,880,0
-   From the corner of your eye, you catch a fleeting glimpse of a shadowy
- figure moving just beyond your sight.
+From the corner of your eye, you catch a fleeting glimpse of a shadowy figure moving just beyond your sight.
 --ROOM 879 END--
 --ROOM 880 START--
 The Temple Of Knowledge_: Level Two
 0,0,881,879
-   Water drips nearby, each drop echoing in the thick, stifling air. The faint
- stench of stagnant water surrounds you.
+Water drips nearby, each drop echoing in the thick, stifling air. The faint stench of stagnant water surrounds you.
 --ROOM 880 END--
 --ROOM 881 START--
 The Temple Of Knowledge_: Level Two
 882,0,0,880
-   Without warning, the ground trembles beneath your feet. Cracks form,
- spreading like veins through the stone.
+Without warning, the ground trembles beneath your feet. Cracks form, spreading like veins through the stone.
 --ROOM 881 END--
 --ROOM 882 START--
 The Temple Of Knowledge_: Level Two
 0,881,870,0
-   The wall collapses in a cascade of stone, releasing a torrent of rushing
- water. The elements reclaim this place, slowly but relentlessly.
+The wall collapses in a cascade of stone, releasing a torrent of rushing water. The elements reclaim this place, slowly but relentlessly.
 --ROOM 882 END--
 --ROOM 883 START--
 The Temple Of Knowledge_: Level Two
 876,884,0,0
-   You stand before a grand entrance that leads to what appears to be a
- sprawling, overgrown garden.
+You stand before a grand entrance that leads to what appears to be a sprawling, overgrown garden.
 --ROOM 883 END--
 --ROOM 884 START--
 The Temple Of Knowledge_: Level Two
 883,0,885,0
-   Lush grass and ancient trees stretch across the area, their verdant beauty a
- stark contrast to the decay around you.
+Lush grass and ancient trees stretch across the area, their verdant beauty a stark contrast to the decay around you.
 --ROOM 884 END--
 --ROOM 885 START--
 The Temple Of Knowledge_: Level Two
 0,886,0,884
-   The fresh, earthy aroma of grass and trees fills your senses, transporting
- you to a world untouched by ruin.
+The fresh, earthy aroma of grass and trees fills your senses, transporting you to a world untouched by ruin.
 --ROOM 885 END--
 --ROOM 886 START--
 The Temple Of Knowledge_: Level Two
 885,887,0,0
-   A strange disorientation overtakes you, as though the very air here carries
- an intoxicating effect.
+A strange disorientation overtakes you, as though the very air here carries an intoxicating effect.
 --ROOM 886 END--
 --ROOM 887 START--
 The Temple Of Knowledge_: Level Two
 886,0,888,0
-   A peculiar mist unfurls across the ground, curling and shifting as if it has
- a mind of its own.
+A peculiar mist unfurls across the ground, curling and shifting as if it has a mind of its own.
 --ROOM 887 END--
 --ROOM 888 START--
 The Temple Of Knowledge_: Level Two
 0,889,0,887
-   Within the mist, faint outlines of figures move silently, specters haunting
- this forgotten place.
+Within the mist, faint outlines of figures move silently, specters haunting this forgotten place.
 --ROOM 888 END--
 --ROOM 889 START--
 The Temple Of Knowledge_: Level Two
 888,890,0,0
-   The landscape shifts, and you find yourself wandering through the remnants
- of an abandoned marketplace.
+The landscape shifts, and you find yourself wandering through the remnants of an abandoned marketplace.
 --ROOM 889 END--
 --ROOM 890 START--
 The Temple Of Knowledge_: Level Two
 889,0,0,891
-   You freeze as a disembodied voice calls out to you from the shadows.
+You freeze as a disembodied voice calls out to you from the shadows.
 --ROOM 890 END--
 --ROOM 891 START--
 The Temple Of Knowledge_: Level Two
 0,892,890,0
-   Through the mist, a grand staircase emerges, leading upward to a raised
- platform.
+Through the mist, a grand staircase emerges, leading upward to a raised platform.
 --ROOM 891 END--
 --ROOM 892 START--
 The Temple Of Knowledge_: Level Two
 891,893,0,0
-   Climbing the stairs, you pause and glance back at the swirling chaos
- below-only to find nothing but emptiness.
+Climbing the stairs, you pause and glance back at the swirling chaos below-only to find nothing but emptiness.
 --ROOM 892 END--
 --ROOM 893 START--
 The Temple Of Knowledge_: Level Two
 892,896,894,895
-   The walls shimmer with a strange, magical glow, shifting between hues of
- green, red, and blue, as if enchanted by an ancient spell.
+The walls shimmer with a strange, magical glow, shifting between hues of green, red, and blue, as if enchanted by an ancient spell.
 --ROOM 893 END--
 --ROOM 894 START--
 The Temple Of Knowledge_: Level Two
 0,0,0,893
-   Before you stands a statue of a strange and enigmatic figure, its visage
- both alien and haunting.
+Before you stands a statue of a strange and enigmatic figure, its visage both alien and haunting.
 --ROOM 894 END--
 --ROOM 895 START--
 The Temple Of Knowledge_: Level Two
 0,0,893,0
-   The statue looms before you, a testament to those who once revered this
- temple as sacred ground.
+The statue looms before you, a testament to those who once revered this temple as sacred ground.
 --ROOM 895 END--
 --ROOM 896 START--
 The Temple Of Knowledge_: Level Two
 893,897,0,0
-   The wind howls through the crumbling structure, carrying with it an
- unsettling sense that this place is utterly foreign, even alien.
+The wind howls through the crumbling structure, carrying with it an unsettling sense that this place is utterly foreign, even alien.
 --ROOM 896 END--
 --ROOM 897 START--
 The Temple Of Knowledge_: Level Two
 896,900,898,899
-   A massive stone doorway towers before you, the icy wind slipping through its
- cracks like a grim invitation to an uncertain future.
+A massive stone doorway towers before you, the icy wind slipping through its cracks like a grim invitation to an uncertain future.
 --ROOM 897 END--
 --ROOM 898 START--
 The Temple Of Knowledge_: Level Two
 0,0,0,897
-   A weathered stone pillar stands tall, a monument to the hands of the
- ancients who shaped this place.
+A weathered stone pillar stands tall, a monument to the hands of the ancients who shaped this place.
 --ROOM 898 END--
 --ROOM 899 START--
 The Temple Of Knowledge_: Level Two
 0,0,897,0
-   The pillar rises before you, intricately carved by those who once called
- this place home-- testament to their legacy.
+The pillar rises before you, intricately carved by those who once called this place home-- testament to their legacy.
 --ROOM 899 END--
 --ROOM 900 START--
 The Temple Of Knowledge_: Level Two
 897,901,0,0
-   With a sudden flash of blinding light, you are transported to a stone
- chamber where a monk stands silently, his presence radiating mystery.
+With a sudden flash of blinding light, you are transported to a stone chamber where a monk stands silently, his presence radiating mystery.
 --ROOM 900 END--
 --ROOM 901 START--
 Malthera's Realm
 900,902,0,0
-   A chilling breeze wraps around you as the blinding light of the doorway
- dims, leaving you standing before a towering monolith of stone. Its sheer
- presence looms ominously, daring you to venture closer.
+A chilling breeze wraps around you as the blinding light of the doorway dims, leaving you standing before a towering monolith of stone. Its sheer presence looms ominously, daring you to venture closer.
 --ROOM 901 END--
 --ROOM 902 START--
 Malthera's Realm
 901,903,0,0
-   You wander through this space, its walls adorned with exquisite tapestries
- that whisper of distant lands and forgotten artistry. Each stitch seems to
- tell a story, drawing you deeper into its allure.
+You wander through this space, its walls adorned with exquisite tapestries that whisper of distant lands and forgotten artistry. Each stitch seems to tell a story, drawing you deeper into its allure.
 --ROOM 902 END--
 --ROOM 903 START--
 Malthera's Realm
 902,0,910,904
-   Beyond these walls lies a forsaken world, yet here, amidst the splendor, it
- feels as though you've stepped into a grand palace untouched by despair.
+Beyond these walls lies a forsaken world, yet here, amidst the splendor, it feels as though you've stepped into a grand palace untouched by despair.
 --ROOM 903 END--
 --ROOM 904 START--
 Malthera's Realm
 0,0,903,905
-   Flickering candlesticks cast wavering shadows on the walls, their feeble
- light revealing an empty chamber steeped in eerie silence.
+Flickering candlesticks cast wavering shadows on the walls, their feeble light revealing an empty chamber steeped in eerie silence.
 --ROOM 904 END--
 --ROOM 905 START--
 Malthera's Realm
 0,906,904,0
-   The room shifts before your eyes, its dimensions warping as if caught in a
- dream. In mere moments, it transforms into a ruined hall, ravaged by decades
- of decay and neglect.
+The room shifts before your eyes, its dimensions warping as if caught in a dream. In mere moments, it transforms into a ruined hall, ravaged by decades of decay and neglect.
 --ROOM 905 END--
 --ROOM 906 START--
 Malthera's Realm
 905,907,0,909
-   As you move through the corridor, an unsettling sight arrests your senses:
- the very walls begin to weep streams of crimson, their eerie flow a silent cry
- of anguish.
+As you move through the corridor, an unsettling sight arrests your senses: the very walls begin to weep streams of crimson, their eerie flow a silent cry of anguish.
 --ROOM 906 END--
 --ROOM 907 START--
 Malthera's Realm
 906,0,0,908
-   The air is thick with the stench of death. Before you stands a grotesque
- sight, a pile of bodies meticulously stacked upon shelves, a macabre mockery
- of order amidst chaos.
+The air is thick with the stench of death. Before you stands a grotesque sight, a pile of bodies meticulously stacked upon shelves, a macabre mockery of order amidst chaos.
 --ROOM 907 END--
 --ROOM 908 START--
 Malthera's Realm
 909,0,907,0
-   With each step, the floor groans beneath your weight, its cracks and creaks
- threatening to give way and plunge you into unknown depths.
+With each step, the floor groans beneath your weight, its cracks and creaks threatening to give way and plunge you into unknown depths.
 --ROOM 908 END--
 --ROOM 909 START--
 Malthera's Realm
 0,908,906,0
-   The ground trembles violently, and the walls rattle with a deafening
- intensity, as though the very structure of this place is alive and restless.
+The ground trembles violently, and the walls rattle with a deafening intensity, as though the very structure of this place is alive and restless.
 --ROOM 909 END--
 --ROOM 910 START--
 Malthera's Realm
 0,0,912,903
-   You ascend a narrow, spiraling staircase, each step echoing in the confined
- space. At the top, you emerge into an open arena, its vastness a stark
- contrast to the claustrophobic climb.
+You ascend a narrow, spiraling staircase, each step echoing in the confined space. At the top, you emerge into an open arena, its vastness a stark contrast to the claustrophobic climb.
 --ROOM 910 END--
 --ROOM 911 START--
 Malthera's Realm
 0,912,0,0
-   Cheers and chants thunder around you as you stumble into what appears to be
- a grand ceremony. The fervent energy of the crowd is electric, yet the purpose
- of their celebration remains unclear.
+Cheers and chants thunder around you as you stumble into what appears to be a grand ceremony. The fervent energy of the crowd is electric, yet the purpose of their celebration remains unclear.
 --ROOM 911 END--
 --ROOM 912 START--
 Malthera's Realm
 911,913,0,910
-   Seated behind an imposing judge's bench, a figure stares down at you with a
- look of inscrutable contentment, their silent gaze heavy with judgment.
+Seated behind an imposing judge's bench, a figure stares down at you with a look of inscrutable contentment, their silent gaze heavy with judgment.
 --ROOM 912 END--
 --ROOM 913 START--
 Malthera's Realm
 912,914,0,0
-   Rows upon rows of hollow-eyed figures stand before you, their vacant stares
- a haunting reminder of those who have lost themselves in this realm devoid of
- life's eternal spark.
+Rows upon rows of hollow-eyed figures stand before you, their vacant stares a haunting reminder of those who have lost themselves in this realm devoid of life's eternal spark.
 --ROOM 913 END--
 --ROOM 914 START--
 Malthera's Realm
 913,0,915,916
-   Your path is suddenly blocked by a striking woman who steps forward with an
- air of authority. ôI am Aelira,ö she declares, her voice cutting through the
- silence like a blade.
+Your path is suddenly blocked by a striking woman who steps forward with an air of authority. ôI am Aelira,ö she declares, her voice cutting through the silence like a blade.
 --ROOM 914 END--
 --ROOM 915 START--
 Malthera's Realm
 0,0,0,914
-   For the first time, you find yourself utterly alone in this chaotic place.
- The silence is almost soothing, offering a rare moment of respite amidst the
- madness.
+For the first time, you find yourself utterly alone in this chaotic place. The silence is almost soothing, offering a rare moment of respite amidst the madness.
 --ROOM 915 END--
 --ROOM 916 START--
 Malthera's Realm
  Broken windows and tattered drapes sway gently in the chilling night breeze,
- whispering secrets of a forgotten past.
-0,917,914,0
+whispering secrets of a forgotten past. 0,917,914,0
 --ROOM 916 END--
 --ROOM 917 START--
 Malthera's Realm
  The walls tremble violently, then collapse, revealing an infinite void of
- impenetrable darkness.
-916,0,0,918
+impenetrable darkness. 916,0,0,918
 --ROOM 917 END--
 --ROOM 918 START--
 Malthera's Realm
 0,919,917,0
-   A sinister laugh echoes around you, and before you can react, you find
- yourself standing in a damp, shadowy dungeon.
+A sinister laugh echoes around you, and before you can react, you find yourself standing in a damp, shadowy dungeon.
 --ROOM 918 END--
 --ROOM 919 START--
 Malthera's Realm
  Screams pierce the air, and an unseen force hurls you against the cold,
- unyielding wall.
-918,924,0,920
+unyielding wall. 918,924,0,920
 --ROOM 919 END--
 --ROOM 920 START--
 Malthera's Realm
 0,0,919,921
-   With every hesitant step down this narrow hall, the walls inch closer, their
- oppressive presence suffocating.
+With every hesitant step down this narrow hall, the walls inch closer, their oppressive presence suffocating.
 --ROOM 920 END--
 --ROOM 921 START--
 Malthera's Realm
 0,922,920,0
-   Summoning every ounce of strength, you squeeze into a cramped room devoid of
- light, save for the flickering glow of your lantern.
+Summoning every ounce of strength, you squeeze into a cramped room devoid of light, save for the flickering glow of your lantern.
 --ROOM 921 END--
 --ROOM 922 START--
 Malthera's Realm
 921,923,0,0
-   You stumble, disoriented, as the air grows thick and heavy, pressing against
- your chest like an unseen weight.
+You stumble, disoriented, as the air grows thick and heavy, pressing against your chest like an unseen weight.
 --ROOM 922 END--
 --ROOM 923 START--
 Malthera's Realm
 922,0,0,0
-   A skeletal figure sits in a decrepit chair, its empty eye sockets seeming to
- watch you with unsettling patience.
+A skeletal figure sits in a decrepit chair, its empty eye sockets seeming to watch you with unsettling patience.
 --ROOM 923 END--
 --ROOM 924 START--
 Malthera's Realm
 919,0,925,0
-   A thick fog engulfs you, and an unseen force makes its presence known with a
- chilling, ghostly touch.
+A thick fog engulfs you, and an unseen force makes its presence known with a chilling, ghostly touch.
 --ROOM 924 END--
 --ROOM 925 START--
 Malthera's Realm
 0,927,926,924
-   You stand before the witch Malthera, her malevolent gaze freezing you in place
- as the cold grip of death begins to take hold.
+You stand before the witch Malthera, her malevolent gaze freezing you in place as the cold grip of death begins to take hold.
 --ROOM 925 END--
 --ROOM 926 START--
 Malthera's Realm
 0,0,0,925
-   You face a dead end: a cold, unyielding stone wall offers no escape, only the
- weight of despair.
+You face a dead end: a cold, unyielding stone wall offers no escape, only the weight of despair.
 --ROOM 926 END--
 --ROOM 927 START--
 Malthera's Realm
 925,928,0,0
-   A blinding flash of light envelops you, and when your vision clears, you find
- yourself in a strange, alien land far from home.
+A blinding flash of light envelops you, and when your vision clears, you find yourself in a strange, alien land far from home.
 --ROOM 927 END--
 --ROOM 928 START--
 Malthera's Realm
 927,0,0,929
-   You stand on a grated floor, gagging as the nauseating stench of decay and rot
- fills the air.
+You stand on a grated floor, gagging as the nauseating stench of decay and rot fills the air.
 --ROOM 928 END--
 --ROOM 929 START--
 Malthera's Realm
 0,930,928,0
-   Jets of steam hiss and burst from the grated floor, forcing you to tread
- carefully with every step.
+Jets of steam hiss and burst from the grated floor, forcing you to tread carefully with every step.
 --ROOM 929 END--
 --ROOM 930 START--
 Malthera's Realm
 929,931,0,0
-   The crackle of a modest fire emanates from a small fireplace, illuminating a
- humble room adorned with a peasant farmer's belongings.
+The crackle of a modest fire emanates from a small fireplace, illuminating a humble room adorned with a peasant farmer's belongings.
 --ROOM 930 END--
 --ROOM 931 START--
 Malthera's Realm
 930,0,932,0
-   A dinner table, neatly set for a meal, suddenly reveals its true nature,
- transforming into something far more sinister.
+A dinner table, neatly set for a meal, suddenly reveals its true nature, transforming into something far more sinister.
 --ROOM 931 END--
 --ROOM 932 START--
 Malthera's Realm
 0,933,0,931
-   The brittle, icy wind bites at your skin as you stand on a stone walkway, its
- destination lost in the shadows ahead.
+The brittle, icy wind bites at your skin as you stand on a stone walkway, its destination lost in the shadows ahead.
 --ROOM 932 END--
 --ROOM 933 START--
 Malthera's Realm
 932,934,0,0
-   The sky darkens ominously, and from the distant forest below, bolts of
- lightning illuminate the treetops in fleeting bursts of light.
+The sky darkens ominously, and from the distant forest below, bolts of lightning illuminate the treetops in fleeting bursts of light.
 --ROOM 933 END--
 --ROOM 934 START--
 Malthera's Realm
 933,937,936,935
-   You wander aimlessly until you realize your footing has changed. Beneath
- you, a platform drifts in the open void, suspended by forces unknown.
+You wander aimlessly until you realize your footing has changed. Beneath you, a platform drifts in the open void, suspended by forces unknown.
 --ROOM 934 END--
 --ROOM 935 START--
 Malthera's Realm
 0,0,934,0
-   From your vantage point, the wilderness stretches endlessly, an ocean of
- trees and rolling hills dissolving into the horizon.
+From your vantage point, the wilderness stretches endlessly, an ocean of trees and rolling hills dissolving into the horizon.
 --ROOM 935 END--
 --ROOM 936 START--
 Malthera's Realm
 0,0,0,934
-   You gaze down upon the lush forest below-untamed, untouched. Not a single
- trace of civilization mars its emerald expanse.
+You gaze down upon the lush forest below-untamed, untouched. Not a single trace of civilization mars its emerald expanse.
 --ROOM 936 END--
 --ROOM 937 START--
 Malthera's Realm
 934,938,0,0
-   Far in the distance, movement catches your eye. The remnants of a
- battlefield remain in turmoil, the chaos still lingering like a wound refusing
- to close.
+Far in the distance, movement catches your eye. The remnants of a battlefield remain in turmoil, the chaos still lingering like a wound refusing to close.
 --ROOM 937 END--
 --ROOM 938 START--
 Malthera's Realm
 937,0,939,0
-   Silence grips the land. The ground is thick with the fallen, a grim
- testament to a battle long past.
+Silence grips the land. The ground is thick with the fallen, a grim testament to a battle long past.
 --ROOM 938 END--
 --ROOM 939 START--
 Malthera's Realm
 0,0,940,938
-   You inhale deeply, but the air carries the weight of something vast-an
- expanse stretching beyond your senses, consuming your vision entirely.
+You inhale deeply, but the air carries the weight of something vast-an expanse stretching beyond your senses, consuming your vision entirely.
 --ROOM 939 END--
 --ROOM 940 START--
 Malthera's Realm
 0,941,0,939
-   A thin mist unfurls at your feet, creeping and curling as it spreads,
- veiling the dead in a ghostly shroud.
+A thin mist unfurls at your feet, creeping and curling as it spreads, veiling the dead in a ghostly shroud.
 --ROOM 940 END--
 --ROOM 941 START--
 Malthera's Realm
 940,942,0,0
-   Through the shifting mist, a lone figure emerges-a woman wandering as if
- searching for something, or lost in something she cannot escape.
+Through the shifting mist, a lone figure emerges-a woman wandering as if searching for something, or lost in something she cannot escape.
 --ROOM 941 END--
 --ROOM 942 START--
 Malthera's Realm
 941,943,0,947
-   The grass lies trampled, the earth marred by deep stains of red. This ground
- has known violence.
+The grass lies trampled, the earth marred by deep stains of red. This ground has known violence.
 --ROOM 942 END--
 --ROOM 943 START--
 Malthera's Realm
 942,0,944,0
-   A winding path leads you down to a shallow river, its waters moving
- sluggishly, carrying whispers of the past downstream.
+A winding path leads you down to a shallow river, its waters moving sluggishly, carrying whispers of the past downstream.
 --ROOM 943 END--
 --ROOM 944 START--
 Malthera's Realm
 0,945,0,943
-   You hold your breath, the only sound the gentle murmur of water. The world
- around you is still, yet something unseen lingers nearby.
+You hold your breath, the only sound the gentle murmur of water. The world around you is still, yet something unseen lingers nearby.
 --ROOM 944 END--
 --ROOM 945 START--
 Malthera's Realm
 944,946,0,0
-   The embrace of the natural world stirs something in you-a longing for home,
- distant and unreachable.
+The embrace of the natural world stirs something in you-a longing for home, distant and unreachable.
 --ROOM 945 END--
 --ROOM 946 START--
 Malthera's Realm
 945,0,963,0
-   An old bridge stretches across the river, its weathered planks creaking
- beneath unseen weight. The path beyond is unknown, yet it beckons.
+An old bridge stretches across the river, its weathered planks creaking beneath unseen weight. The path beyond is unknown, yet it beckons.
 --ROOM 946 END--
 --ROOM 947 START--
 Malthera's Realm
 0,948,942,0
-   The sun sinks behind the horizon, and in mere moments, the world is
- swallowed by darkness.
+The sun sinks behind the horizon, and in mere moments, the world is swallowed by darkness.
 --ROOM 947 END--
 --ROOM 948 START--
 Malthera's Realm
 947,949,0,0
-   A lone figure sits in a weathered chair, overlooking the field of the dead.
- A silent spectator, or something more?
+A lone figure sits in a weathered chair, overlooking the field of the dead. A silent spectator, or something more?
 --ROOM 948 END--
 --ROOM 949 START--
 Malthera's Realm
 948,0,0,950
-   You stand in the middle of an empty field, the only sign of past presence a
- broken fence, its splintered wood leaning as if in surrender.
+You stand in the middle of an empty field, the only sign of past presence a broken fence, its splintered wood leaning as if in surrender.
 --ROOM 949 END--
 --ROOM 950 START--
 Malthera's Realm
 0,954,949,951
-   The wind picks up, its breath cold against your skin. Your lantern flickers,
- the flame struggling against the encroaching dark.
+The wind picks up, its breath cold against your skin. Your lantern flickers, the flame struggling against the encroaching dark.
 --ROOM 950 END--
 --ROOM 951 START--
 Malthera's Realm
 0,952,950,0
-   You wander through the overgrown remnants of a forgotten farm, the scent of
- damp earth and decay hanging in the air. The skeletal remains of fences and
- structures stand as silent witnesses to time's neglect.
+You wander through the overgrown remnants of a forgotten farm, the scent of damp earth and decay hanging in the air. The skeletal remains of fences and structures stand as silent witnesses to time's neglect.
 --ROOM 951 END--
 --ROOM 952 START--
 Malthera's Realm
 951,0,0,953
-   Knee-high wheat sways gently in the cold breeze as you tread carefully
- through the field. Your footsteps are the only sound, save for the faint
- rustling of unseen creatures. The flickering glow of your lantern cuts through
- the darkness, a fragile beacon of hope.
+Knee-high wheat sways gently in the cold breeze as you tread carefully through the field. Your footsteps are the only sound, save for the faint rustling of unseen creatures. The flickering glow of your lantern cuts through the darkness, a fragile beacon of hope.
 --ROOM 952 END--
 --ROOM 953 START--
 Malthera's Realm
 0,0,952,996
-   Far in the distance, barely visible through the mist, stands the outline of
- a farmhouse. Weathered and silent, it looms like a specter against the night
- sky.
+Far in the distance, barely visible through the mist, stands the outline of a farmhouse. Weathered and silent, it looms like a specter against the night sky.
 --ROOM 953 END--
 --ROOM 954 START--
 Malthera's Realm
 950,955,0,0
-   After what feels like hours of trudging through the wilderness, you finally
- halt before the edge of a dense, foreboding swamp. Thick vines dangle like
- grasping fingers, and the air is heavy with the scent of stagnant water.
+After what feels like hours of trudging through the wilderness, you finally halt before the edge of a dense, foreboding swamp. Thick vines dangle like grasping fingers, and the air is heavy with the scent of stagnant water.
 --ROOM 954 END--
 --ROOM 955 START--
 Malthera's Realm
 954,957,0,956
-   The swamp is alive with the chorus of croaking frogs, their rhythmic calls
- echoing through the trees. Pairs of glowing red eyes hover in the darknes
- watching, waiting-before vanishing into the shadows.
+The swamp is alive with the chorus of croaking frogs, their rhythmic calls echoing through the trees. Pairs of glowing red eyes hover in the darknes watching, waiting-before vanishing into the shadows.
 --ROOM 955 END--
 --ROOM 956 START--
 Malthera's Realm
 0,0,955,0
-   You stand at the last solid patch of land, gazing out over a sea of mist.
- The fog shifts and swirls, obscuring whatever lurks beneath its ghostly veil.
+You stand at the last solid patch of land, gazing out over a sea of mist. The fog shifts and swirls, obscuring whatever lurks beneath its ghostly veil.
 --ROOM 956 END--
 --ROOM 957 START--
 Malthera's Realm
 955,0,958,0
-   Forcing your way through tangled undergrowth, you wade into the murky water,
- its chill seeping into your bones. Step by step, you push forward until your
- feet find purchase on solid ground once more.
+Forcing your way through tangled undergrowth, you wade into the murky water, its chill seeping into your bones. Step by step, you push forward until your feet find purchase on solid ground once more.
 --ROOM 957 END--
 --ROOM 958 START--
 Malthera's Realm
 0,0,959,957
-   A sudden movement brushes against your leg, sending a shiver up your spine.
- Then, just as you freeze in place, a low hiss cuts through the still air.
+A sudden movement brushes against your leg, sending a shiver up your spine. Then, just as you freeze in place, a low hiss cuts through the still air.
 --ROOM 958 END--
 --ROOM 959 START--
 Malthera's Realm
 0,960,0,958
-   Without warning, the ground trembles violently beneath you. Jets of noxious
- swamp gas erupt into the air, their sickly glow illuminating the haze. Then,
- in the blink of an eye, it all vanishes-leaving only a cracked, dry riverbed
- in its place.
+Without warning, the ground trembles violently beneath you. Jets of noxious swamp gas erupt into the air, their sickly glow illuminating the haze. Then, in the blink of an eye, it all vanishes-leaving only a cracked, dry riverbed in its place.
 --ROOM 959 END--
 --ROOM 960 START--
 Malthera's Realm
 959,961,0,0
-   From the shifting earth, a massive skull emerges, its hollow eyes staring
- into the void. With a deep groan, its maw yawns open, revealing a narrow
- staircase descending into darkness.
+From the shifting earth, a massive skull emerges, its hollow eyes staring into the void. With a deep groan, its maw yawns open, revealing a narrow staircase descending into darkness.
 --ROOM 960 END--
 --ROOM 961 START--
 Malthera's Realm
 960,0,0,962
-   Carefully, you descend into the abyss, the air growing colder with each
- step. At last, your boots crunch against frozen ground, the oppressive silence
- pressing in around you.
+Carefully, you descend into the abyss, the air growing colder with each step. At last, your boots crunch against frozen ground, the oppressive silence pressing in around you.
 --ROOM 961 END--
 --ROOM 962 START--
 Malthera's Realm
 0,1021,961,0
-   A chill settles deep into your bones as you take in your surroundings. The
- walls, ceiling, and floor are all coated in a thick layer of frost, their icy
- sheen reflecting the dim glow of your lantern.
+A chill settles deep into your bones as you take in your surroundings. The walls, ceiling, and floor are all coated in a thick layer of frost, their icy sheen reflecting the dim glow of your lantern.
 --ROOM 962 END--
 --ROOM 963 START--
 Vorrok's Hollow
 0,0,964,946
-   Jagged stone juts from the earth, forming cold, unyielding walls around this
- hollow space.
+Jagged stone juts from the earth, forming cold, unyielding walls around this hollow space.
 --ROOM 963 END--
 --ROOM 964 START--
 Vorrok's Hollow
 966,0,965,963
-   Gnarled, weathered trees cling desperately to life, their twisted forms
- standing like silent sentinels.
+Gnarled, weathered trees cling desperately to life, their twisted forms standing like silent sentinels.
 --ROOM 964 END--
 --ROOM 965 START--
 Vorrok's Hollow
 0,0,0,964
-   A scattering of moss-covered rocks lies before you, remnants of time's slow
- and steady erosion.
+A scattering of moss-covered rocks lies before you, remnants of time's slow and steady erosion.
 --ROOM 965 END--
 --ROOM 966 START--
 Vorrok's Hollow
 967,964,0,0
-   You push through the tangled brush and branches, forging deeper into the
- wilderness you thought you knew.
+You push through the tangled brush and branches, forging deeper into the wilderness you thought you knew.
 --ROOM 966 END--
 --ROOM 967 START--
 Vorrok's Hollow
 0,966,968,0
-   The air turns icy as you arrive at a worn stone trail, its path vanishing
- into the unknown.
+The air turns icy as you arrive at a worn stone trail, its path vanishing into the unknown.
 --ROOM 967 END--
 --ROOM 968 START--
 Vorrok's Hollow
 0,0,969,967
-   A distant birdcall shatters the eerie silence, a stark reminder that you are
- utterly lost in this strange land.
+A distant birdcall shatters the eerie silence, a stark reminder that you are utterly lost in this strange land.
 --ROOM 968 END--
 --ROOM 969 START--
 Vorrok's Hollow
 970,0,0,968
-   Stop right there, adventurer! This is Gribnock territory! a harsh voice
- barks, cutting through the still air.
+Stop right there, adventurer! This is Gribnock territory! a harsh voice barks, cutting through the still air.
 --ROOM 969 END--
 --ROOM 970 START--
 Vorrok's Hollow
 971,969,0,0
-   You step through a towering wooden gate, revealing a hidden village,
- untouched by the outside world.
+You step through a towering wooden gate, revealing a hidden village, untouched by the outside world.
 --ROOM 970 END--
 --ROOM 971 START--
 Vorrok's Hollow
 972,970,0,0
-   Scattered throughout the village are small, makeshift huts, built from
- whatever nature had to offer.
+Scattered throughout the village are small, makeshift huts, built from whatever nature had to offer.
 --ROOM 971 END--
 --ROOM 972 START--
 Vorrok's Hollow
 974,971,991,973
-   Strange beings wander aimlessly, their expressions lost in deep and
- unfathomable thoughts.
+Strange beings wander aimlessly, their expressions lost in deep and unfathomable thoughts.
 --ROOM 972 END--
 --ROOM 973 START--
 Vorrok's Hollow
 0,0,972,0
-   A blinding flash of white light engulfs you. As your vision clears, the
- village Elder stands before you.
+A blinding flash of white light engulfs you. As your vision clears, the village Elder stands before you.
 --ROOM 973 END--
 --ROOM 974 START--
 Vorrok's Hollow
 975,972,0,0
-   Around you, small, carefully tended fields whisper of hard labor and the
- hope for a bountiful harvest.
+Around you, small, carefully tended fields whisper of hard labor and the hope for a bountiful harvest.
 --ROOM 974 END--
 --ROOM 975 START--
 Vorrok's Hollow
 0,974,982,976
-   The lilting tune of a traveling bard mingles with the laughter of children
- at play.
+The lilting tune of a traveling bard mingles with the laughter of children at play.
 --ROOM 975 END--
 --ROOM 976 START--
 Vorrok's Hollow
 977,0,975,0
-   A narrow path winds its way to a secluded corner of the village, shrouded in
- quiet solitude.
+A narrow path winds its way to a secluded corner of the village, shrouded in quiet solitude.
 --ROOM 976 END--
 --ROOM 977 START--
 Vorrok's Hollow
 978,976,0,0
-   A high stone wall looms ahead, shielding this sacred ground from the noise
- of the outside world. Here, the dead rest in undisturbed peace.
+A high stone wall looms ahead, shielding this sacred ground from the noise of the outside world. Here, the dead rest in undisturbed peace.
 --ROOM 977 END--
 --ROOM 978 START--
 Vorrok's Hollow
 979,977,981,0
-   Silence hangs heavy in the air, broken only by the whisper of the wind over
- neatly arranged graves.
+Silence hangs heavy in the air, broken only by the whisper of the wind over neatly arranged graves.
 --ROOM 978 END--
 --ROOM 979 START--
 Vorrok's Hollow
 0,978,980,0
-   A lone bench sits off to the side, overlooking the graves-a quiet place to
- reflect among lost souls.
+A lone bench sits off to the side, overlooking the graves-a quiet place to reflect among lost souls.
 --ROOM 979 END--
 --ROOM 980 START--
 Vorrok's Hollow
 0,981,0,979
-   A small bird flits across the ground, pecking and hopping as it searches for
- its next meal.
+A small bird flits across the ground, pecking and hopping as it searches for its next meal.
 --ROOM 980 END--
 --ROOM 981 START--
 Vorrok's Hollow
 980,0,0,978
-   Your steps falter as you find yourself standing before a freshly dug grave,
- its emptiness waiting in quiet expectation.
+Your steps falter as you find yourself standing before a freshly dug grave, its emptiness waiting in quiet expectation.
 --ROOM 981 END--
 --ROOM 982 START--
 Vorrok's Hollow
 983,0,984,975
-   A row of horse stables stretches before you, each sheltering sturdy beasts,
- their breath misting in the cool air. These noble creatures stand ready to aid
- their masters in tilling the land and hauling heavy loads.
+A row of horse stables stretches before you, each sheltering sturdy beasts, their breath misting in the cool air. These noble creatures stand ready to aid their masters in tilling the land and hauling heavy loads.
 --ROOM 982 END--
 --ROOM 983 START--
 Vorrok's Hollow
 0,982,0,0
-   A forgotten home stands before you, its windows boarded up, its walls
- sagging under the weight of time. The world has moved on, leaving it a silent
- relic of lives once lived.
+A forgotten home stands before you, its windows boarded up, its walls sagging under the weight of time. The world has moved on, leaving it a silent relic of lives once lived.
 --ROOM 983 END--
 --ROOM 984 START--
 Vorrok's Hollow
 0,989,985,982
-   A low stone wall, weathered and crumbling, struggles to hold back the
- encroaching earth. Once a proud marker of farmland, it now serves as a quiet
- testament to generations past.
+A low stone wall, weathered and crumbling, struggles to hold back the encroaching earth. Once a proud marker of farmland, it now serves as a quiet testament to generations past.
 --ROOM 984 END--
 --ROOM 985 START--
 Vorrok's Hollow
 986,0,988,984
-   You stand at the entrance of a bustling mill. Towering stacks of raw timber
- wait their turn to be shaped into planks, feeding the lifeblood of the
- village's construction.
+You stand at the entrance of a bustling mill. Towering stacks of raw timber wait their turn to be shaped into planks, feeding the lifeblood of the village's construction.
 --ROOM 985 END--
 --ROOM 986 START--
 Vorrok's Hollow
 0,985,987,0
-   A massive saw looms before you, its jagged teeth biting relentlessly into
- the wood. A laborer, lost in his work, guides the blade with practiced
- precision.
+A massive saw looms before you, its jagged teeth biting relentlessly into the wood. A laborer, lost in his work, guides the blade with practiced precision.
 --ROOM 986 END--
 --ROOM 987 START--
 Vorrok's Hollow
 0,988,0,986
-   The scent of fresh-cut wood lingers in the air as a fine layer of sawdust
- coats the many tables scattered about. The piercing wail of metal on wood
- echoes through the mill, drowning out all but the rhythmic hum of industry.
+The scent of fresh-cut wood lingers in the air as a fine layer of sawdust coats the many tables scattered about. The piercing wail of metal on wood echoes through the mill, drowning out all but the rhythmic hum of industry.
 --ROOM 987 END--
 --ROOM 988 START--
 Vorrok's Hollow
 987,0,0,985
-   At a small, cluttered table, the mill's foreman pores over invoices, his
- brow furrowed in concentration. The weight of logistics and labor rests
- heavily on his shoulders.
+At a small, cluttered table, the mill's foreman pores over invoices, his brow furrowed in concentration. The weight of logistics and labor rests heavily on his shoulders.
 --ROOM 988 END--
 --ROOM 989 START--
 Vorrok's Hollow
 984,990,0,0
-   You cross a narrow wooden bridge spanning a placid pond. Beneath the
- rippling surface, small fish dart through the water, their movements barely
- disturbing the tranquil scene.
+You cross a narrow wooden bridge spanning a placid pond. Beneath the rippling surface, small fish dart through the water, their movements barely disturbing the tranquil scene.
 --ROOM 989 END--
 --ROOM 990 START--
 Vorrok's Hollow
 989,0,992,991
-   Patches of grass and earth stretch around you, an untamed contrast to the
- well-trodden paths of the village.
+Patches of grass and earth stretch around you, an untamed contrast to the well-trodden paths of the village.
 --ROOM 990 END--
 --ROOM 991 START--
 Vorrok's Hollow
 0,0,990,972
-   A winding dirt path snakes through the village, guiding your steps. In the
- distance, a thin column of smoke rises into the sky, beckoning you toward
- signs of life.
+A winding dirt path snakes through the village, guiding your steps. In the distance, a thin column of smoke rises into the sky, beckoning you toward signs of life.
 --ROOM 991 END--
 --ROOM 992 START--
 Vorrok's Hollow
 0,995,993,990
-   A large burn pit sits at the village's heart, its warmth drawing people in
- like moths to a flame. Wooden benches are arranged nearby, offering a place to
- sit, cook, and share stories beneath the open sky.
+A large burn pit sits at the village's heart, its warmth drawing people in like moths to a flame. Wooden benches are arranged nearby, offering a place to sit, cook, and share stories beneath the open sky.
 --ROOM 992 END--
 --ROOM 993 START--
 Vorrok's Hollow
 0,994,0,992
-   Laughter and cheers fill the air as a small group works together, roasting a
- wild pig over the fire. The scent of sizzling meat mingles with the crackling
- of the flames.
+Laughter and cheers fill the air as a small group works together, roasting a wild pig over the fire. The scent of sizzling meat mingles with the crackling of the flames.
 --ROOM 993 END--
 --ROOM 994 START--
 Vorrok's Hollow
 993,0,0,995
-   The air is heavy with stillness. Here, alone with your thoughts, time seems
- to slow, offering you a quiet moment of reflection.
+The air is heavy with stillness. Here, alone with your thoughts, time seems to slow, offering you a quiet moment of reflection.
 --ROOM 994 END--
 --ROOM 995 START--
 Vorrok's Hollow
 992,0,994,0
-   Wandering the village, fatigue slowly claims you. Finding a quiet spot, you
- settle down to rest, letting weariness pull you into its embrace.
+Wandering the village, fatigue slowly claims you. Finding a quiet spot, you settle down to rest, letting weariness pull you into its embrace.
 --ROOM 995 END--
 --ROOM 996 START--
 The Witherwood Homestead
 0,0,953,997
-   The air turns frigid, and an eerie silence settles over the forgotten world,
- stretching endlessly into the void.
+The air turns frigid, and an eerie silence settles over the forgotten world, stretching endlessly into the void.
 --ROOM 996 END--
 --ROOM 997 START--
 The Witherwood Homestead
 0,0,996,998
-   A narrow trail winds ahead, leading to the unknown. In the distance, barely
- visible through the mist, stands the outline of an old farmhouse, its presence
- both inviting and foreboding.
+A narrow trail winds ahead, leading to the unknown. In the distance, barely visible through the mist, stands the outline of an old farmhouse, its presence both inviting and foreboding.
 --ROOM 997 END--
 --ROOM 998 START--
 The Witherwood Homestead
 1002,0,997,999
-   A ghostly mist rises from the earth, curling around your feet and consuming
- the landscape in a shroud of uncertainty.
+A ghostly mist rises from the earth, curling around your feet and consuming the landscape in a shroud of uncertainty.
 --ROOM 998 END--
 --ROOM 999 START--
 The Witherwood Homestead
 0,1000,998,0
-   Time has reclaimed the land-weathered wooden fences crumble into the soil,
- vanishing like memories fading into dust.
+Time has reclaimed the land-weathered wooden fences crumble into the soil, vanishing like memories fading into dust.
 --ROOM 999 END--
 --ROOM 1000 START--
 The Witherwood Homestead
 999,0,0,1001
-   Each step feels unsteady, the ground shifting beneath you, soft and
- yielding, like freshly fallen snow.
+Each step feels unsteady, the ground shifting beneath you, soft and yielding, like freshly fallen snow.
 --ROOM 1000 END--
 --ROOM 1001 START--
 The Witherwood Homestead
 0,0,1000,0
-   A rusted, decaying wagon sits in your path, its broken frame a silent
- monument to the past.
+A rusted, decaying wagon sits in your path, its broken frame a silent monument to the past.
 --ROOM 1001 END--
 --ROOM 1002 START--
 The Witherwood Homestead
 1003,998,0,0
-   Following the overgrown path, you arrive at the entrance of a long-abandoned
- farmhouse, its walls sagging, its timbers rotting under years of neglect.
+Following the overgrown path, you arrive at the entrance of a long-abandoned farmhouse, its walls sagging, its timbers rotting under years of neglect.
 --ROOM 1002 END--
 --ROOM 1003 START--
 The Witherwood Homestead
 0,1002,1004,1008
-   Stepping inside, you hold your lantern high-the feeble glow barely pushing
- back the consuming darkness.
+Stepping inside, you hold your lantern high-the feeble glow barely pushing back the consuming darkness.
 --ROOM 1003 END--
 --ROOM 1004 START--
 The Witherwood Homestead
 1005,0,0,1003
-   As you move through the gloom, the ancient floorboards groan beneath your
- weight, their creaks swallowed by the suffocating silence.
+As you move through the gloom, the ancient floorboards groan beneath your weight, their creaks swallowed by the suffocating silence.
 --ROOM 1004 END--
 --ROOM 1005 START--
 The Witherwood Homestead
 1006,1004,1007,0
-   The windows stand open, yet no breeze stirs. A strange unease washes over
- you, as if unseen eyes are watching.
+The windows stand open, yet no breeze stirs. A strange unease washes over you, as if unseen eyes are watching.
 --ROOM 1005 END--
 --ROOM 1006 START--
 The Witherwood Homestead
 0,1005,0,0
-   Dust clings to the walls, and deep claw-like scratches mar the wooden
- surfaces-evidence of struggles long past.
+Dust clings to the walls, and deep claw-like scratches mar the wooden surfaces-evidence of struggles long past.
 --ROOM 1006 END--
 --ROOM 1007 START--
 The Witherwood Homestead
 0,0,0,1005
-   You stand before a boarded-up window, its jagged planks draped in thick,
- undisturbed cobwebs.
+You stand before a boarded-up window, its jagged planks draped in thick, undisturbed cobwebs.
 --ROOM 1007 END--
 --ROOM 1008 START--
 The Witherwood Homestead
 1012,0,1003,1009
-   You press on, searching desperately for any sign of life in this forsaken
- place.
+You press on, searching desperately for any sign of life in this forsaken place.
 --ROOM 1008 END--
 --ROOM 1009 START--
 The Witherwood Homestead
 0,1010,1008,0
-   A sudden crash shatters the silence, the sound reverberating through the
- empty halls. Something unseen stirs in the darkness.
+A sudden crash shatters the silence, the sound reverberating through the empty halls. Something unseen stirs in the darkness.
 --ROOM 1009 END--
 --ROOM 1010 START--
 The Witherwood Homestead
 1009,0,0,1011
-   The air here is cold, the very walls exuding an unshakable sense of dread
- and abandonment.
+The air here is cold, the very walls exuding an unshakable sense of dread and abandonment.
 --ROOM 1010 END--
 --ROOM 1011 START--
 The Witherwood Homestead
 0,0,1010,0
-   A chill wind cuts through the darkness, wrapping around you like unseen
- fingers.
+A chill wind cuts through the darkness, wrapping around you like unseen fingers.
 --ROOM 1011 END--
 --ROOM 1012 START--
 The Witherwood Homestead
 1013,1008,0,0
-   Blackness engulfs you. Somewhere in the distance, faint laughter drifts
- through the void.
+Blackness engulfs you. Somewhere in the distance, faint laughter drifts through the void.
 --ROOM 1012 END--
 --ROOM 1013 START--
 The Witherwood Homestead
 0,1012,0,1014
-   The wind howls in strange, broken tones. A tightness grips your chest, and
- for a moment, you feel yourself teetering between existence and oblivion.
+The wind howls in strange, broken tones. A tightness grips your chest, and for a moment, you feel yourself teetering between existence and oblivion.
 --ROOM 1013 END--
 --ROOM 1014 START--
 The Witherwood Homestead
 1016,0,1013,1015
-   You wander through the desolate halls. The doors to many rooms have been
- nailed shut, sealing away their secrets.
+You wander through the desolate halls. The doors to many rooms have been nailed shut, sealing away their secrets.
 --ROOM 1014 END--
 --ROOM 1015 START--
 The Witherwood Homestead
 0,0,1014,0
-   A piercing scream erupts from behind a boarded-up door, its source unseen,
- but not alone.
+A piercing scream erupts from behind a boarded-up door, its source unseen, but not alone.
 --ROOM 1015 END--
 --ROOM 1016 START--
 The Witherwood Homestead
 1017,1014,0,0
-   The walls tremble, near collapse, yet unseen spirits still haunt these
- halls, their whispers threading through the decay.
+The walls tremble, near collapse, yet unseen spirits still haunt these halls, their whispers threading through the decay.
 --ROOM 1016 END--
 --ROOM 1017 START--
 The Witherwood Homestead
 1020,1016,1018,0
-   Laughter echoes, sharp and unnatural. Then, with a groan, the wall shifts
- revealing a hidden room.
+Laughter echoes, sharp and unnatural. Then, with a groan, the wall shifts revealing a hidden room.
 --ROOM 1017 END--
 --ROOM 1018 START--
 The Witherwood Homestead
 1019,0,0,1017
-   Stacks of old crates line the walls. In the center, a crude table stands,
- its surface scarred. A single burnt-out candle rests upon a tarnished plate.
+Stacks of old crates line the walls. In the center, a crude table stands, its surface scarred. A single burnt-out candle rests upon a tarnished plate.
 --ROOM 1018 END--
 --ROOM 1019 START--
 The Witherwood Homestead
 0,1018,0,1020
-   Neatly folded piles of clothing sit atop a table, untouched, waiting for an
- owner who will never return.
+Neatly folded piles of clothing sit atop a table, untouched, waiting for an owner who will never return.
 --ROOM 1019 END--
 --ROOM 1020 START--
 The Witherwood Homestead
 0,1017,1019,0
-   A figure stands before you-the keeper of the guild-gazing at you with a look
- of puzzlement, as if you are the true mystery here.
+A figure stands before you-the keeper of the guild-gazing at you with a look of puzzlement, as if you are the true mystery here.
 --ROOM 1020 END--
 --ROOM 1021 START--
 The Glacial Veil
 962,1022,0,0
-   The path ahead grows colder with each step, the once-firm ground now
- hardened by frost. A chill clings to the air, warning of the icy expanse
- ahead.
+The path ahead grows colder with each step, the once-firm ground now hardened by frost. A chill clings to the air, warning of the icy expanse ahead.
 --ROOM 1021 END--
 --ROOM 1022 START--
 The Glacial Veil
 1021,1023,0,0
-   A thin veil of snow drifts past, swirling in the wind. Soon, the world
- around you becomes a blur, as if swallowed by an endless white void.
+A thin veil of snow drifts past, swirling in the wind. Soon, the world around you becomes a blur, as if swallowed by an endless white void.
 --ROOM 1022 END--
 --ROOM 1023 START--
 The Glacial Veil
 1022,0,1024,0
-   The air turns thin and biting. You move past a cluster of dead trees, their
- skeletal branches weighed down by layers of snow, standing as silent sentinels
- in the frozen wasteland.
+The air turns thin and biting. You move past a cluster of dead trees, their skeletal branches weighed down by layers of snow, standing as silent sentinels in the frozen wasteland.
 --ROOM 1023 END--
 --ROOM 1024 START--
 The Glacial Veil
 0,1027,1025,1023
-   A sudden gust of wind howls through the desolate landscape, carrying an
- eerie sense of displacement-like stepping into a world untethered from time.
+A sudden gust of wind howls through the desolate landscape, carrying an eerie sense of displacement-like stepping into a world untethered from time.
 --ROOM 1024 END--
 --ROOM 1025 START--
 The Glacial Veil
 1026,0,0,1024
-   Cresting a small snow-covered mound, you spot a frozen form half-buried in
- the ice. The remains of a goblin, its body locked in a final grimace, long
- abandoned to the elements.
+Cresting a small snow-covered mound, you spot a frozen form half-buried in the ice. The remains of a goblin, its body locked in a final grimace, long abandoned to the elements.
 --ROOM 1025 END--
 --ROOM 1026 START--
 The Glacial Veil
 0,1025,0,0
-   Standing at the edge of a jagged cliff, you peer down upon a small,
- forgotten settlement. Snow blankets its rooftops, and silence grips the land
- below.
+Standing at the edge of a jagged cliff, you peer down upon a small, forgotten settlement. Snow blankets its rooftops, and silence grips the land below.
 --ROOM 1026 END--
 --ROOM 1027 START--
 The Glacial Veil
 1024,1028,0,0
-   The wind twists and swirls around you as you approach a weathered bridge,
- its stones slick with ice, its wooden planks rotting from years of neglect.
+The wind twists and swirls around you as you approach a weathered bridge, its stones slick with ice, its wooden planks rotting from years of neglect.
 --ROOM 1027 END--
 --ROOM 1028 START--
 The Glacial Veil
 1027,0,1029,0
-   A heavy silence settles as you step onto the bridge. Each footstep echoes
- faintly, lost in the vast emptiness surrounding you.
+A heavy silence settles as you step onto the bridge. Each footstep echoes faintly, lost in the vast emptiness surrounding you.
 --ROOM 1028 END--
 --ROOM 1029 START--
 The Glacial Veil
 0,1030,0,1028
-   A ruined shack stands nearby, its walls warped and splintered by time.
- Snowdrifts press against its crumbling frame, a monument to a long-faded past.
+A ruined shack stands nearby, its walls warped and splintered by time. Snowdrifts press against its crumbling frame, a monument to a long-faded past.
 --ROOM 1029 END--
 --ROOM 1030 START--
 The Glacial Veil
 1029,1031,0,0
-   Everything here is cold, silent, and forsaken. The land itself feels
- abandoned, the air thick with the weight of forgotten years.
+Everything here is cold, silent, and forsaken. The land itself feels abandoned, the air thick with the weight of forgotten years.
 --ROOM 1030 END--
 --ROOM 1031 START--
 The Glacial Veil
 1030,0,1032,0
-   Frozen furrows stretch before you-plowed fields, long since claimed by
- winter's grasp. Once tilled by steady hands, they now lie barren beneath the
- ice.
+Frozen furrows stretch before you-plowed fields, long since claimed by winter's grasp. Once tilled by steady hands, they now lie barren beneath the ice.
 --ROOM 1031 END--
 --ROOM 1032 START--
 The Glacial Veil
 0,1035,1033,1031
-   The bitter cold gnaws at your resolve, slowing your steps. Then, to your
- astonishment, you spot the glow of a campfire flickering in the distance-a
- rare sign of life in this forsaken place.
+The bitter cold gnaws at your resolve, slowing your steps. Then, to your astonishment, you spot the glow of a campfire flickering in the distance-a rare sign of life in this forsaken place.
 --ROOM 1032 END--
 --ROOM 1033 START--
 The Glacial Veil
 1034,0,0,1032
-   You stand before a ramshackle shack, its structure barely holding together.
- Through a grimy window, a single candle flickers, casting long shadows across
- the walls.
+You stand before a ramshackle shack, its structure barely holding together. Through a grimy window, a single candle flickers, casting long shadows across the walls.
 --ROOM 1033 END--
 --ROOM 1034 START--
 The Glacial Veil
 0,1033,0,0
-   Carefully, you step inside, navigating through the cluttered space. The dim
- glow of the candle guides you-until, from the shadows, an old woman emerges.
- Her eyes widen in shock as she sees you.
+Carefully, you step inside, navigating through the cluttered space. The dim glow of the candle guides you-until, from the shadows, an old woman emerges. Her eyes widen in shock as she sees you.
 --ROOM 1034 END--
 --ROOM 1035 START--
 The Glacial Veil
 1032,1036,0,0
-   The bitter cold gnaws at your skin with every passing moment.
+The bitter cold gnaws at your skin with every passing moment.
 --ROOM 1035 END--
 --ROOM 1036 START--
 The Glacial Veil
 1035,0,0,1037
-   A bloodcurdling scream pierces the air as a rider on a dark steed charges
- toward you.
+A bloodcurdling scream pierces the air as a rider on a dark steed charges toward you.
 --ROOM 1036 END--
 --ROOM 1037 START--
 The Glacial Veil
 0,1038,1036,1042
-   Empty buildings stand in eerie silence, homes long abandoned and void of
- life.
+Empty buildings stand in eerie silence, homes long abandoned and void of life.
 --ROOM 1037 END--
 --ROOM 1038 START--
 The Glacial Veil
 1037,1039,0,0
-   A well looms before you, entombed in ice. Frozen figures stand motionless,
- their forms lost to time.
+A well looms before you, entombed in ice. Frozen figures stand motionless, their forms lost to time.
 --ROOM 1038 END--
 --ROOM 1039 START--
 The Glacial Veil
 1038,0,1040,0
-   You trudge onward through this forsaken place, each step a battle against
- the creeping frost.
+You trudge onward through this forsaken place, each step a battle against the creeping frost.
 --ROOM 1039 END--
 --ROOM 1040 START--
 The Glacial Veil
 0,1041,0,1039
-   A staircase, carved deep into the earth, spirals into the unknown darkness
- below.
+A staircase, carved deep into the earth, spirals into the unknown darkness below.
 --ROOM 1040 END--
 --ROOM 1041 START--
 The Glacial Veil
 1040,1056,0,0
-   The howling wind cuts through the silence, sending a shiver down your spine.
+The howling wind cuts through the silence, sending a shiver down your spine.
 --ROOM 1041 END--
 --ROOM 1042 START--
 The Glacial Veil
 1043,0,1037,0
-   A wooden pathway creaks beneath your feet, leading you toward a vast frozen
- lake.
+A wooden pathway creaks beneath your feet, leading you toward a vast frozen lake.
 --ROOM 1042 END--
 --ROOM 1043 START--
 The Glacial Veil
 0,1042,0,1044
-   A small hut stands at the lake's edge, its weathered frame gazing out over
- the icy expanse.
+A small hut stands at the lake's edge, its weathered frame gazing out over the icy expanse.
 --ROOM 1043 END--
 --ROOM 1044 START--
 The Glacial Veil
 0,0,1043,1045
-   You push open the door and step into a home pieced together with whatever
- scraps could be found.
+You push open the door and step into a home pieced together with whatever scraps could be found.
 --ROOM 1044 END--
 --ROOM 1045 START--
 The Glacial Veil
 1046,1051,1044,0
-   A lone monk sits before you, lost in the vast abyss of solitude.
+A lone monk sits before you, lost in the vast abyss of solitude.
 --ROOM 1045 END--
 --ROOM 1046 START--
 The Glacial Veil
 1047,1045,0,0
-   A narrow staircase descends into a crypt hidden beneath this forsaken place.
+A narrow staircase descends into a crypt hidden beneath this forsaken place.
 --ROOM 1046 END--
 --ROOM 1047 START--
 The Glacial Veil
 1050,1046,1048,1049
-   From the stifling darkness, you advance cautiously, uncovering relics long
- forgotten by time.
+From the stifling darkness, you advance cautiously, uncovering relics long forgotten by time.
 --ROOM 1047 END--
 --ROOM 1048 START--
 The Glacial Veil
 0,0,0,1047
-   A small storeroom, crammed with whatever could be scavenged from the
- pantries of the departed.
+A small storeroom, crammed with whatever could be scavenged from the pantries of the departed.
 --ROOM 1048 END--
 --ROOM 1049 START--
 The Glacial Veil
 0,0,1047,0
-   Nothing but a crumbling, dust-covered wall.
+Nothing but a crumbling, dust-covered wall.
 --ROOM 1049 END--
 --ROOM 1050 START--
 The Glacial Veil
 0,1047,0,0
-   A crude, makeshift room-bare save for a tattered bed and a collection of
- misfit blankets.
+A crude, makeshift room-bare save for a tattered bed and a collection of misfit blankets.
 --ROOM 1050 END--
 --ROOM 1051 START--
 The Glacial Veil
 1045,1052,0,0
-   Deep scratches mar the walls, while rusted chains dangle ominously from
- their fixtures.
+Deep scratches mar the walls, while rusted chains dangle ominously from their fixtures.
 --ROOM 1051 END--
 --ROOM 1052 START--
 The Glacial Veil
 1051,1055,1053,1054
-   Standing before you is a grotesque entity, a lifeless corpse brought
- unnaturally back to motion.
+Standing before you is a grotesque entity, a lifeless corpse brought unnaturally back to motion.
 --ROOM 1052 END--
 --ROOM 1053 START--
 The Glacial Veil
 0,0,0,1052
-   A blood-soaked table reeks of death, its surface littered with burnt-out
- candles.
+A blood-soaked table reeks of death, its surface littered with burnt-out candles.
 --ROOM 1053 END--
 --ROOM 1054 START--
 The Glacial Veil
 0,0,1052,0
-   A small pile of hay rests against the cold stone wall, a desperate attempt
- at a bed.
+A small pile of hay rests against the cold stone wall, a desperate attempt at a bed.
 --ROOM 1054 END--
 --ROOM 1055 START--
 The Glacial Veil
 1052,0,0,0
-   A dented plate sits on the floor beside a bucket of stagnant water-a grim
- meal for whatever wretched thing resides here.
+A dented plate sits on the floor beside a bucket of stagnant water-a grim meal for whatever wretched thing resides here.
 --ROOM 1055 END--
 --ROOM 1056 START--
 The Cursed Dominion
 1041,1057,0,0
-   You stand before the entrance to a mechanized world, where jets of steam
- hiss from unseen pipes, and the shrill whistle of venting valves pierces the
- air.
+You stand before the entrance to a mechanized world, where jets of steam hiss from unseen pipes, and the shrill whistle of venting valves pierces the air.
 --ROOM 1056 END--
 --ROOM 1057 START--
 The Cursed Dominion
 1056,0,0,1058
-   Candlelight flickers within glass-domed sconces, casting restless shadows as
- the very walls shift and grind, reshaping the room around you.
+Candlelight flickers within glass-domed sconces, casting restless shadows as the very walls shift and grind, reshaping the room around you.
 --ROOM 1057 END--
 --ROOM 1058 START--
 The Cursed Dominion
 0,1059,1057,0
-   A bell tolls in the distance, its metallic chime reverberating through this
- strange, alien chamber.
+A bell tolls in the distance, its metallic chime reverberating through this strange, alien chamber.
 --ROOM 1058 END--
 --ROOM 1059 START--
 The Cursed Dominion
 1058,0,0,1060
-   The ground trembles beneath your feet as a mechanized walker lurches forth
- from the wall, its movements clumsy yet determined, blindly carrying out some
- long-forgotten task.
+The ground trembles beneath your feet as a mechanized walker lurches forth from the wall, its movements clumsy yet determined, blindly carrying out some long-forgotten task.
 --ROOM 1059 END--
 --ROOM 1060 START--
 The Cursed Dominion
 0,1061,1059,0
-   A faint stench of charred wood lingers in the air, rising from the unseen
- depths of roaring boilers.
+A faint stench of charred wood lingers in the air, rising from the unseen depths of roaring boilers.
 --ROOM 1060 END--
 --ROOM 1061 START--
 The Cursed Dominion
 1060,1062,0,0
-   Each step sends a quiver through the unstable floor beneath you, as if the
- very ground resents your presence.
+Each step sends a quiver through the unstable floor beneath you, as if the very ground resents your presence.
 --ROOM 1061 END--
 --ROOM 1062 START--
 The Cursed Dominion
 1061,0,1063,1081
-   You stand at the edge of a vast industrial abyss, peering down at a fiery
- mine where workers toil relentlessly in the sweltering depths.
+You stand at the edge of a vast industrial abyss, peering down at a fiery mine where workers toil relentlessly in the sweltering depths.
 --ROOM 1062 END--
 --ROOM 1063 START--
 The Cursed Dominion
 0,1064,0,1062
-   Your footsteps echo sharply against cold stone walls, the sound swallowed by
- the void beyond.
+Your footsteps echo sharply against cold stone walls, the sound swallowed by the void beyond.
 --ROOM 1063 END--
 --ROOM 1064 START--
 The Cursed Dominion
 1063,0,1065,0
-   A precarious walkway sways beneath you, suspended over the ceaseless labor
- of miners chipping away at the earth below.
+A precarious walkway sways beneath you, suspended over the ceaseless labor of miners chipping away at the earth below.
 --ROOM 1064 END--
 --ROOM 1065 START--
 The Cursed Dominion
 0,1066,0,1064
-   The rhythmic clatter of pickaxes striking stone rings through the cavern, an
- unending dirge in this infernal pit.
+The rhythmic clatter of pickaxes striking stone rings through the cavern, an unending dirge in this infernal pit.
 --ROOM 1065 END--
 --ROOM 1066 START--
 The Cursed Dominion
 1065,1067,0,0
-   A weary guard stands before you, his tired eyes barely registering your
- presence.
+A weary guard stands before you, his tired eyes barely registering your presence.
 --ROOM 1066 END--
 --ROOM 1067 START--
 The Cursed Dominion
 1066,1068,0,0
-   A strange, eerie glow seeps from the ground beneath your feet, leading you
- toward a vantage point that overlooks the unknown.
+A strange, eerie glow seeps from the ground beneath your feet, leading you toward a vantage point that overlooks the unknown.
 --ROOM 1067 END--
 --ROOM 1068 START--
 The Cursed Dominion
 1067,1069,0,0
-   For a fleeting moment, reality itself seems foreign, the world around you
- shifting into something uncanny, almost alien.
+For a fleeting moment, reality itself seems foreign, the world around you shifting into something uncanny, almost alien.
 --ROOM 1068 END--
 --ROOM 1069 START--
 The Cursed Dominion
 1068,0,0,1070
-   Distant echoes of wailing and anguish slither through the air, the cries of
- unseen souls lost to torment.
+Distant echoes of wailing and anguish slither through the air, the cries of unseen souls lost to torment.
 --ROOM 1069 END--
 --ROOM 1070 START--
 The Cursed Dominion
 0,1071,1069,0
-   Heat rises in suffocating waves, sapping your strength and clouding your
- vision in this oppressive inferno.
+Heat rises in suffocating waves, sapping your strength and clouding your vision in this oppressive inferno.
 --ROOM 1070 END--
 --ROOM 1071 START--
 The Cursed Dominion
 1070,0,0,1072
-   Below, a small group of workers toil in eerie silence, as though trapped in
- a world separate from your own.
+Below, a small group of workers toil in eerie silence, as though trapped in a world separate from your own.
 --ROOM 1071 END--
 --ROOM 1072 START--
 The Cursed Dominion
 0,1082,1071,1073
-   With every step through this wretched place, a question gnaws at you-what
- sins have condemned these people to such a fate?
+With every step through this wretched place, a question gnaws at you-what sins have condemned these people to such a fate?
 --ROOM 1072 END--
 --ROOM 1073 START--
 The Cursed Dominion
 1074,0,1072,0
-   A groan of strained metal fills the air as rusted beams bend and protest
- beneath your weight.
+A groan of strained metal fills the air as rusted beams bend and protest beneath your weight.
 --ROOM 1073 END--
 --ROOM 1074 START--
 The Cursed Dominion
 0,1073,0,0
-   Everything here reeks of desolation-a place where life holds no worth, and
- existence is merely endured.
+Everything here reeks of desolation-a place where life holds no worth, and existence is merely endured.
 --ROOM 1074 END--
 --ROOM 1075 START--
 The Cursed Dominion
 1076,0,1074,1075
-   From below, a sudden, terrified scream shatters the droning rhythm of the
- mine, then fades into unsettling silence.
+From below, a sudden, terrified scream shatters the droning rhythm of the mine, then fades into unsettling silence.
 --ROOM 1075 END--
 --ROOM 1076 START--
 The Cursed Dominion
 1077,1075,0,0
-   A monstrous growl reverberates through the cavern, drowning out even the
- relentless strikes of pickaxes.
+A monstrous growl reverberates through the cavern, drowning out even the relentless strikes of pickaxes.
 --ROOM 1076 END--
 --ROOM 1077 START--
 The Cursed Dominion
 1078,1076,0,0
-   A weary-eyed guard watches you, her expression blank, her exhaustion
- palpable.
+A weary-eyed guard watches you, her expression blank, her exhaustion palpable.
 --ROOM 1077 END--
 --ROOM 1078 START--
 The Cursed Dominion
 1079,1077,0,0
-   This place feels almost infernal, as if it exists on the very edge of the
- living world, teetering toward something far worse.
+This place feels almost infernal, as if it exists on the very edge of the living world, teetering toward something far worse.
 --ROOM 1078 END--
 --ROOM 1079 START--
 The Cursed Dominion
 0,1078,1080,0
-   The steady clinking of pickaxes against stone echoes endlessly, a rhythmic
- chant of labor and despair.
+The steady clinking of pickaxes against stone echoes endlessly, a rhythmic chant of labor and despair.
 --ROOM 1079 END--
 --ROOM 1080 START--
 The Cursed Dominion
 1081,0,0,1079
-   The platform beneath you sways precariously, groaning with every shift,
- threatening to collapse into the darkness below.
+The platform beneath you sways precariously, groaning with every shift, threatening to collapse into the darkness below.
 --ROOM 1080 END--
 --ROOM 1081 START--
 The Cursed Dominion
 0,1080,1062,0
-   The heat from unseen fires licks at your skin, forcing you to pause, to
- breathe, to endure.
+The heat from unseen fires licks at your skin, forcing you to pause, to breathe, to endure.
 --ROOM 1081 END--
 --ROOM 1082 START--
 The Cursed Dominion
 1072,1083,0,0
-   You come upon a narrow pathway carved into the rock. The wind howls through
- the chasm, sending an icy shiver down your spine.
+You come upon a narrow pathway carved into the rock. The wind howls through the chasm, sending an icy shiver down your spine.
 --ROOM 1082 END--
 --ROOM 1083 START--
 The Cursed Dominion
 1082,1084,0,0
-   A jet of steam bursts from the floor, momentarily blinding you. As it
- clears, you find yourself within a secluded sanctuary, severed from the rest
- of the world.
+A jet of steam bursts from the floor, momentarily blinding you. As it clears, you find yourself within a secluded sanctuary, severed from the rest of the world.
 --ROOM 1083 END--
 --ROOM 1084 START--
 The Aurelic Factory
 1083,1085,0,0
-   You stand amidst a world of mechanized chaos. Strange metal beasts lumber
- through the haze, steam hissing from their joints like the breath of some
- unseen behemoth.
+You stand amidst a world of mechanized chaos. Strange metal beasts lumber through the haze, steam hissing from their joints like the breath of some unseen behemoth.
 --ROOM 1084 END--
 --ROOM 1085 START--
 The Aurelic Factory
 1084,0,1086,0
-   An eerie green glow emanates from the walls, reflecting off the hulking
- forms of mechanized workers-each radiating the same unearthly luminescence.
+An eerie green glow emanates from the walls, reflecting off the hulking forms of mechanized workers-each radiating the same unearthly luminescence.
 --ROOM 1085 END--
 --ROOM 1086 START--
 The Aurelic Factory
 0,0,1087,1085
-   This place exists outside of time, a forgotten remnant of an age that never
- was, yet refuses to fade.
+This place exists outside of time, a forgotten remnant of an age that never was, yet refuses to fade.
 --ROOM 1086 END--
 --ROOM 1087 START--
 The Aurelic Factory
 0,1088,0,1086
-   The walls have been stripped away, revealing a vast chamber dominated by a
- massive boiler, its pipes and valves exhaling bursts of scalding steam.
+The walls have been stripped away, revealing a vast chamber dominated by a massive boiler, its pipes and valves exhaling bursts of scalding steam.
 --ROOM 1087 END--
 --ROOM 1088 START--
 The Aurelic Factory
 1087,1089,0,0
-   Pillars of steam shoot into the air, obscuring your vision. The figures
- around you continue their tasks, oblivious to your presence.
+Pillars of steam shoot into the air, obscuring your vision. The figures around you continue their tasks, oblivious to your presence.
 --ROOM 1088 END--
 --ROOM 1089 START--
 The Aurelic Factory
 1088,1090,0,1096
-   The air is thick with anguished cries, rising from the workers near the
- boilers screams that sound as if they are being devoured by something unseen.
+The air is thick with anguished cries, rising from the workers near the boilers screams that sound as if they are being devoured by something unseen.
 --ROOM 1089 END--
 --ROOM 1090 START--
 The Aurelic Factory
 1089,0,1091,0
-   You stand in a grand hall, its ceiling secured by aged wooden beams and
- sturdy pillars, the scent of dust and decay heavy in the air.
+You stand in a grand hall, its ceiling secured by aged wooden beams and sturdy pillars, the scent of dust and decay heavy in the air.
 --ROOM 1090 END--
 --ROOM 1091 START--
 The Aurelic Factory
 0,0,1092,1090
-   Awe washes over you as you gaze upon enormous slabs of stone. Something
- about them exudes a numbing, almost suffocating pain.
+Awe washes over you as you gaze upon enormous slabs of stone. Something about them exudes a numbing, almost suffocating pain.
 --ROOM 1091 END--
 --ROOM 1092 START--
 The Aurelic Factory
 0,1095,1093,1091
-   Before you, a row of monks stand with arms raised, their voices crying out
- to the heavens-but whether in worship or despair, you cannot tell.
+Before you, a row of monks stand with arms raised, their voices crying out to the heavens-but whether in worship or despair, you cannot tell.
 --ROOM 1092 END--
 --ROOM 1093 START--
 The Aurelic Factory
 0,1094,0,1092
-   From the darkness emerges nothing but a heap of jagged rock, its presence
- strangely foreboding.
+From the darkness emerges nothing but a heap of jagged rock, its presence strangely foreboding.
 --ROOM 1093 END--
 --ROOM 1094 START--
 The Aurelic Factory
 1093,0,0,1095
-   A thick layer of dust clings to the walls, undisturbed by time or motion, as
- you wander through the desolate space.
+A thick layer of dust clings to the walls, undisturbed by time or motion, as you wander through the desolate space.
 --ROOM 1094 END--
 --ROOM 1095 START--
 The Aurelic Factory
 1092,0,1094,0
-   A peculiar bust stands before you, its features unfamiliar, its glassy eyes
- seeming to watch your every move.
+A peculiar bust stands before you, its features unfamiliar, its glassy eyes seeming to watch your every move.
 --ROOM 1095 END--
 --ROOM 1096 START--
 The Aurelic Factory
 1097,1105,1089,1098
-   A massive metal pipe extends into the earth, its opening wide and
- foreboding, as if waiting to swallow all who dare approach.
+A massive metal pipe extends into the earth, its opening wide and foreboding, as if waiting to swallow all who dare approach.
 --ROOM 1096 END--
 --ROOM 1097 START--
 The Aurelic Factory
 0,1096,0,0
-   A collection of shattered, rusted parts litters the ground-the remains of
- once-mighty mechanized walkers, now reduced to scrap.
+A collection of shattered, rusted parts litters the ground-the remains of once-mighty mechanized walkers, now reduced to scrap.
 --ROOM 1097 END--
 --ROOM 1098 START--
 The Aurelic Factory
 0,0,1096,1099
-   This place feels far older than it first appeared, its very essence
- whispering secrets of a forgotten past.
+This place feels far older than it first appeared, its very essence whispering secrets of a forgotten past.
 --ROOM 1098 END--
 --ROOM 1099 START--
 The Aurelic Factory
 0,1100,1098,0
-   A shrill whistle echoes through the corridors, its source unseen. In the
- flickering shadows, something moves.
+A shrill whistle echoes through the corridors, its source unseen. In the flickering shadows, something moves.
 --ROOM 1099 END--
 --ROOM 1100 START--
 The Aurelic Factory
 1099,1101,0,0
-   High above, mechanized walkers cling to the walls, tearing away at rock and
- ore with unwavering precision.
+High above, mechanized walkers cling to the walls, tearing away at rock and ore with unwavering precision.
 --ROOM 1100 END--
 --ROOM 1101 START--
 The Aurelic Factory
 1100,1102,0,1104
-   In the center of the room, a cloaked figure stands motionless, watching over
- the walkers with an unsettling stillness.
+In the center of the room, a cloaked figure stands motionless, watching over the walkers with an unsettling stillness.
 --ROOM 1101 END--
 --ROOM 1102 START--
 The Aurelic Factory
 1101,0,0,1103
-   The walls have been carved away, leaving behind a hollowed-out cavern that
- now sits abandoned and lifeless.
+The walls have been carved away, leaving behind a hollowed-out cavern that now sits abandoned and lifeless.
 --ROOM 1102 END--
 --ROOM 1103 START--
 The Aurelic Factory
 1104,0,1102,0
-   A pile of rubble blocks your path, its jagged edges hinting at recent
- destruction.
+A pile of rubble blocks your path, its jagged edges hinting at recent destruction.
 --ROOM 1103 END--
 --ROOM 1104 START--
 The Aurelic Factory
 0,1103,1101,0
-   Strange markings sprawl across the walls, their meaning unknown. A sudden
- unease settles over you, as if the very symbols are watching.
+Strange markings sprawl across the walls, their meaning unknown. A sudden unease settles over you, as if the very symbols are watching.
 --ROOM 1104 END--
 --ROOM 1105 START--
 The Aurelic Factory
 1096,1106,0,0
-   You stand at the mouth of a cavern, darkness curling inward like an open
- maw, waiting.
+You stand at the mouth of a cavern, darkness curling inward like an open maw, waiting.
 --ROOM 1105 END--
 --ROOM 1106 START--
 The Aurelic Factory
 1105,1107,0,0
-   Before you lies the hollowed remains of a once-majestic throne room, now a
- husk of faded power.
+Before you lies the hollowed remains of a once-majestic throne room, now a husk of faded power.
 --ROOM 1106 END--
 --ROOM 1107 START--
 The Aurelic Factory
 1106,1110,1108,0
-   Standing amidst the ruins is the Archmechanist, his keen eyes scanning the
- newly unearthed chambers, absorbing every detail with methodical precision.
+Standing amidst the ruins is the Archmechanist, his keen eyes scanning the newly unearthed chambers, absorbing every detail with methodical precision.
 --ROOM 1107 END--
 --ROOM 1108 START--
 The Aurelic Factory
 0,1109,0,1107
-   Ancient relics line the walls, uncovered by the relentless excavation silent
- witnesses to a history long buried.
+Ancient relics line the walls, uncovered by the relentless excavation silent witnesses to a history long buried.
 --ROOM 1108 END--
 --ROOM 1109 START--
 The Aurelic Factory
 1108,0,0,1110
-   The ground quakes beneath you as the wall ahead shudders-then bursts open.
- From the earth emerges a colossal steam-powered drill, gnashing through stone
- like a ravenous beast.
+The ground quakes beneath you as the wall ahead shudders-then bursts open. From the earth emerges a colossal steam-powered drill, gnashing through stone like a ravenous beast.
 --ROOM 1109 END--
 --ROOM 1110 START--
 The Aurelic Factory
 1107,0,1109,1111
-   A copper sphere spins and hums in the air, its motion seemingly powering
- something unseen, something immense.
+A copper sphere spins and hums in the air, its motion seemingly powering something unseen, something immense.
 --ROOM 1110 END--
 --ROOM 1111 START--
 The Aurelic Factory
 0,1112,1110,0
-   Scattered across the floor lie the broken bodies of workers, their lifeless
- forms evidence of a brutal slaughter by something monstrous.
+Scattered across the floor lie the broken bodies of workers, their lifeless forms evidence of a brutal slaughter by something monstrous.
 --ROOM 1111 END--
 --ROOM 1112 START--
 The Aurelic Factory
 1111,1113,0,0
-   A monk's corpse is slumped against the wall, his lifeless gaze fixed on
- something only he could see.
+A monk's corpse is slumped against the wall, his lifeless gaze fixed on something only he could see.
 --ROOM 1112 END--
 --ROOM 1113 START--
 The Aurelic Factory
 1112,1114,0,0
-   Before you stands a doorway of unknown material-smooth, featureless, and
- entirely alien to the world around it.
+Before you stands a doorway of unknown material-smooth, featureless, and entirely alien to the world around it.
 --ROOM 1113 END--
 --ROOM 1114 START--
 The Aurelic Factory
 1113,1115,0,0
-   You step into a realm of shifting forms and writhing geometry. A sickening
- wave of nausea overtakes you, followed by a sudden, bone-chilling cold. The
- air itself seems to fight against your presence.
+You step into a realm of shifting forms and writhing geometry. A sickening wave of nausea overtakes you, followed by a sudden, bone-chilling cold. The air itself seems to fight against your presence.
 --ROOM 1114 END--
 --ROOM 1115 START--
 Malthera's Abyss
 1114,1116,0,0
-   You stand before a long-forgotten temple, its ancient stone fa?ade barely
- visible beneath layers of creeping vines and time-worn decay. The air hums
- with an eerie stillness, as if the temple itself is holding its breath.
+You stand before a long-forgotten temple, its ancient stone fa?ade barely visible beneath layers of creeping vines and time-worn decay. The air hums with an eerie stillness, as if the temple itself is holding its breath.
 --ROOM 1115 END--
 --ROOM 1116 START--
 Malthera's Abyss
 1115,1117,0,0
-   The world around you stirs-walls groan, unseen things skitter, and a
- strange, rhythmic hum pulses in the air. It is as if the very stones of this
- place are awakening.
+The world around you stirs-walls groan, unseen things skitter, and a strange, rhythmic hum pulses in the air. It is as if the very stones of this place are awakening.
 --ROOM 1116 END--
 --ROOM 1117 START--
 Malthera's Abyss
 1116,1118,0,0
-   Towering stone pillars stretch toward the ceiling, their intricate carvings
- speaking of a lost era. Something about their craftsmanship tugs at your
- memory, a whisper of home in this forsaken place.
+Towering stone pillars stretch toward the ceiling, their intricate carvings speaking of a lost era. Something about their craftsmanship tugs at your memory, a whisper of home in this forsaken place.
 --ROOM 1117 END--
 --ROOM 1118 START--
 Malthera's Abyss
 1117,1119,0,0
-   You there... the adventurer I've heard so much about. My pets have been
- watching you. Malthera's voice booms through the chamber, its sheer force
- pressing against you like an unseen weight.
+You there... the adventurer I've heard so much about. My pets have been watching you. Malthera's voice booms through the chamber, its sheer force pressing against you like an unseen weight.
 --ROOM 1118 END--
 --ROOM 1119 START--
 Malthera's Abyss
 1118,1134,1120,1127
-   You stand at a crossroads, each path disappearing into the unknown. The
- faint sound of laughter drifts through the air, though its source remains
- elusive-mocking, beckoning, or warning, you cannot tell.
+You stand at a crossroads, each path disappearing into the unknown. The faint sound of laughter drifts through the air, though its source remains elusive-mocking, beckoning, or warning, you cannot tell.
 --ROOM 1119 END--
 --ROOM 1120 START--
 Malthera's Abyss
 0,0,1121,1119
-   A narrow hallway stretches ahead, shadows twisting in the flickering light
- of a wandering flame. It dances just beyond reach, moving with an almost
- playful intent, as if daring you to follow.
+A narrow hallway stretches ahead, shadows twisting in the flickering light of a wandering flame. It dances just beyond reach, moving with an almost playful intent, as if daring you to follow.
 --ROOM 1120 END--
 --ROOM 1121 START--
 Malthera's Abyss
 1122,1126,0,1120
-   The sound of dripping water echoes through the chamber, yet no source can be
- seen. An ancient statue looms before you, its stone visage worn and cracked,
- as though weeping with the weight of forgotten years.
+The sound of dripping water echoes through the chamber, yet no source can be seen. An ancient statue looms before you, its stone visage worn and cracked, as though weeping with the weight of forgotten years.
 --ROOM 1121 END--
 --ROOM 1122 START--
 Malthera's Abyss
 0,1121,1123,0
-   You halt in your tracks, eyes widening as the King himself stands before
- you. And yet, something is terribly wrong-this is no place for a ruler, no
- throne room of splendor. The walls whisper of secrets best left buried.
+You halt in your tracks, eyes widening as the King himself stands before you. And yet, something is terribly wrong-this is no place for a ruler, no throne room of splendor. The walls whisper of secrets best left buried.
 --ROOM 1122 END--
 --ROOM 1123 START--
 Malthera's Abyss
 0,1124,0,1122
-   With every step, the darkness seems to swallow you whole. This abyss is
- neither forsaken nor forgotten-no, something here remembers. And it is
- watching.
+With every step, the darkness seems to swallow you whole. This abyss is neither forsaken nor forgotten-no, something here remembers. And it is watching.
 --ROOM 1123 END--
 --ROOM 1124 START--
 Malthera's Abyss
 1123,1125,0,0
-   A cold breeze brushes past, sending a shiver through your spine. The
- sensation is more than just the chill-it is the feeling of something unseen,
- standing just behind you.
+A cold breeze brushes past, sending a shiver through your spine. The sensation is more than just the chill-it is the feeling of something unseen, standing just behind you.
 --ROOM 1124 END--
 --ROOM 1125 START--
 Malthera's Abyss
 1124,0,0,1126
-   The walls press in, dark and unyielding, their surfaces rough with age and
- neglect. A presence lingers here, clinging to the shadows like a forgotten
- whisper.
+The walls press in, dark and unyielding, their surfaces rough with age and neglect. A presence lingers here, clinging to the shadows like a forgotten whisper.
 --ROOM 1125 END--
 --ROOM 1126 START--
 Malthera's Abyss
 1121,0,1125,0
-   Everything about this place feels... wrong. Familiar, yet wholly alien, like echoes from
- a world that never was. A creeping sensation prickles at your skin-eyes in the darkness,
- watching, waiting. And then, without thinking, you run.
+Everything about this place feels... wrong. Familiar, yet wholly alien, like echoes from a world that never was. A creeping sensation prickles at your skin-eyes in the darkness, watching, waiting. And then, without thinking, you run.
 --ROOM 1126 END--
 --ROOM 1127 START--
 Malthera's Abyss
 0,0,1119,1128
-   As you step cautiously through the dimly lit space, your gaze drifts across
- the surroundings-until it lands upon a lifeless body slumped against the wall,
- frozen in eternal stillness.
+As you step cautiously through the dimly lit space, your gaze drifts across the surroundings-until it lands upon a lifeless body slumped against the wall, frozen in eternal stillness.
 --ROOM 1127 END--
 --ROOM 1128 START--
 Malthera's Abyss
 1133,1129,1127,0
-   A haunting melody drifts through the air as you find yourself in a chamber
- lined with towering mirrors. Reflections shimmer and distort, making it
- impossible to tell where reality ends and illusion begins.
+A haunting melody drifts through the air as you find yourself in a chamber lined with towering mirrors. Reflections shimmer and distort, making it impossible to tell where reality ends and illusion begins.
 --ROOM 1128 END--
 --ROOM 1129 START--
 Malthera's Abyss
 1128,0,0,1130
-   Laughter echoes faintly, its source unknown. As your eyes adjust, you
- realize you are surrounded-statues, eerily lifelike, gathered as if frozen
- mid-conversation.
+Laughter echoes faintly, its source unknown. As your eyes adjust, you realize you are surrounded-statues, eerily lifelike, gathered as if frozen mid-conversation.
 --ROOM 1129 END--
 --ROOM 1130 START--
 Malthera's Abyss
 1131,0,1129,0
-   Silence. A suffocating, endless silence. Darkness stretches beyond sight, an
- abyss of the unknown waiting just beyond your reach.
+Silence. A suffocating, endless silence. Darkness stretches beyond sight, an abyss of the unknown waiting just beyond your reach.
 --ROOM 1130 END--
 --ROOM 1131 START--
 Malthera's Abyss
 1132,1130,0,0
-   She floats before you, suspended over a bottomless pit-the ghastly woman in
- black. Her hollow eyes seem to see through you, her presence sending a chill
- through your very soul.
+She floats before you, suspended over a bottomless pit-the ghastly woman in black. Her hollow eyes seem to see through you, her presence sending a chill through your very soul.
 --ROOM 1131 END--
 --ROOM 1132 START--
 Malthera's Abyss
 0,1131,1133,0
-   The temperature plummets in an instant, your breath visible in the icy air.
- From the corner of your eye, movement-someone appears, materializing from the
- void.
+The temperature plummets in an instant, your breath visible in the icy air. From the corner of your eye, movement-someone appears, materializing from the void.
 --ROOM 1132 END--
 --ROOM 1133 START--
 Malthera's Abyss
 0,1128,0,1132
-   Laughter-disembodied, distant-bounces off the cold stone walls, twisting and
- warping as if the room itself is amused by your presence.
+Laughter-disembodied, distant-bounces off the cold stone walls, twisting and warping as if the room itself is amused by your presence.
 --ROOM 1133 END--
 --ROOM 1134 START--
 Malthera's Abyss
 1119,1135,0,0
-   The walls of this hallway stare back at you, each surface adorned with
- solemn, carved faces. Their expressions remain unreadable, their purpose
- unknown.
+The walls of this hallway stare back at you, each surface adorned with solemn, carved faces. Their expressions remain unreadable, their purpose unknown.
 --ROOM 1134 END--
 --ROOM 1135 START--
 Malthera's Abyss
 1134,1136,0,0
-   More faces, endless and unblinking, carved into the stone. As you pause, the
- sound of laughter rises from them, faint yet unmistakable.
+More faces, endless and unblinking, carved into the stone. As you pause, the sound of laughter rises from them, faint yet unmistakable.
 --ROOM 1135 END--
 --ROOM 1136 START--
 Malthera's Abyss
 1135,1137,0,0
-   Without warning, the wall crumbles away in a cascade of dust and rubble.
- From the swirling debris, a stone figure emerges-its form shifting, taking
- life before your very eyes.
+Without warning, the wall crumbles away in a cascade of dust and rubble. From the swirling debris, a stone figure emerges-its form shifting, taking life before your very eyes.
 --ROOM 1136 END--
 --ROOM 1137 START--
 Malthera's Abyss
 1136,0,1138,1145
-   A heavy silence hangs in the air, wrapping around you like a thick fog. Yet
- beneath it lurks something unseen, an unsettling presence that refuses to be
- ignored.
+A heavy silence hangs in the air, wrapping around you like a thick fog. Yet beneath it lurks something unseen, an unsettling presence that refuses to be ignored.
 --ROOM 1137 END--
 --ROOM 1138 START--
 Malthera's Abyss
 0,0,1139,1137
-   You enter a tall and narrow hall, its towering walls pressing in like the
- ribs of some ancient beast. At the far end, the shadows part to reveal a
- long-forbidden cathedral-rediscovered, yet still holding its secrets close.
+You enter a tall and narrow hall, its towering walls pressing in like the ribs of some ancient beast. At the far end, the shadows part to reveal a long-forbidden cathedral-rediscovered, yet still holding its secrets close.
 --ROOM 1138 END--
 --ROOM 1139 START--
 Malthera's Abyss
 1140,1144,0,1138
-   Dust-laden benches sit in perfect rows, their surfaces worn smooth by the
- devotion of long-departed faithful. An eerie stillness lingers, as if the
- congregation has merely stepped away for a moment, yet centuries have passed.
+Dust-laden benches sit in perfect rows, their surfaces worn smooth by the devotion of long-departed faithful. An eerie stillness lingers, as if the congregation has merely stepped away for a moment, yet centuries have passed.
 --ROOM 1139 END--
 --ROOM 1140 START--
 Malthera's Abyss
 0,1139,1141,0
-   A torn portrait hangs precariously from the wall, its subject unrecognizable
- beneath layers of decay. Flickering torchlight dances across the ruined image,
- casting fleeting glimpses of a face that may never have existed.
+A torn portrait hangs precariously from the wall, its subject unrecognizable beneath layers of decay. Flickering torchlight dances across the ruined image, casting fleeting glimpses of a face that may never have existed.
 --ROOM 1140 END--
 --ROOM 1141 START--
 Malthera's Abyss
 0,1142,0,1140
-   Ah, a visitor from the outside world... How unexpected. The voice is regal,
- yet hollow, as if spoken by a priest who has long since faded into memory.
+Ah, a visitor from the outside world... How unexpected. The voice is regal, yet hollow, as if spoken by a priest who has long since faded into memory.
 --ROOM 1141 END--
 --ROOM 1142 START--
 Malthera's Abyss
 1141,1143,0,0
-   A massive altar, hewn from a single block of stone, looms before you. At its
- base, a deep pit gapes, blackened by centuries of burnt offerings. The air is
- thick with the ghosts of old prayers and sacrifices long forgotten.
+A massive altar, hewn from a single block of stone, looms before you. At its base, a deep pit gapes, blackened by centuries of burnt offerings. The air is thick with the ghosts of old prayers and sacrifices long forgotten.
 --ROOM 1142 END--
 --ROOM 1143 START--
 Malthera's Abyss
 1142,0,1152,1144
-   You stand at a crossroads. One path leads to a hidden stairwell, descending
- into an abyss untouched by time. The other offers the only way back-though
- something tells you the way home may not be as you left it.
+You stand at a crossroads. One path leads to a hidden stairwell, descending into an abyss untouched by time. The other offers the only way back-though something tells you the way home may not be as you left it.
 --ROOM 1143 END--
 --ROOM 1144 START--
 Malthera's Abyss
 1139,0,1143,0
-   There is something disturbingly familiar about this place. The architecture,
- the scent of old stone and wax, the solemn hush-it all speaks of an ancient
- church, yet no faith you recognize ever worshipped here.
+There is something disturbingly familiar about this place. The architecture, the scent of old stone and wax, the solemn hush-it all speaks of an ancient church, yet no faith you recognize ever worshipped here.
 --ROOM 1144 END--
 --ROOM 1145 START--
 Malthera's Abyss
 0,0,1137,1146
-   A forgotten chamber, lost between time and memory. Whatever purpose it once
- held is eroded, its meaning slipping through your fingers like dust.
+A forgotten chamber, lost between time and memory. Whatever purpose it once held is eroded, its meaning slipping through your fingers like dust.
 --ROOM 1145 END--
 --ROOM 1146 START--
 Malthera's Abyss
 1147,1151,1145,0
-   Unfinished walls rise at uneven angles, the stonework crude in some places,
- impossibly precise in others. The floor beneath your feet shifts ever so
- slightly, as if uncertain whether it belongs to this world.
+Unfinished walls rise at uneven angles, the stonework crude in some places, impossibly precise in others. The floor beneath your feet shifts ever so slightly, as if uncertain whether it belongs to this world.
 --ROOM 1146 END--
 --ROOM 1147 START--
 Malthera's Abyss
 0,1146,0,1148
-   Piles of rubble litter the floor, remnants of a structure that was never
- completed-or one that has yet to finish forming. The stones seem to wait,
- patient and unyielding, for something only they remember.
+Piles of rubble litter the floor, remnants of a structure that was never completed-or one that has yet to finish forming. The stones seem to wait, patient and unyielding, for something only they remember.
 --ROOM 1147 END--
 --ROOM 1148 START--
 Malthera's Abyss
 0,1149,1147,0
-   The walls bear deep scars, rough-hewn by pickaxes that sought to carve order
- from the unknown. The marks seem almost fresh, as if the laborers only just
- set down their tools... or never truly left.
+The walls bear deep scars, rough-hewn by pickaxes that sought to carve order from the unknown. The marks seem almost fresh, as if the laborers only just set down their tools... or never truly left.
 --ROOM 1148 END--
 --ROOM 1149 START--
 Malthera's Abyss
 1148,1150,0,0
-   A tired old soul stands before you, eyes heavy with the weight of years. He
- surveys the ruin around him, not with despair, but with the resignation of one
- who has seen this place fall into ruin before.
+A tired old soul stands before you, eyes heavy with the weight of years. He surveys the ruin around him, not with despair, but with the resignation of one who has seen this place fall into ruin before.
 --ROOM 1149 END--
 --ROOM 1150 START--
 Malthera's Abyss
 1149,0,1151,0
-   Scattered remnants of mining equipment rust where they were abandoned, their
- metal frames twisted and broken. Whatever was being unearthed here, its
- secrets remain buried.
+Scattered remnants of mining equipment rust where they were abandoned, their metal frames twisted and broken. Whatever was being unearthed here, its secrets remain buried.
 --ROOM 1150 END--
 --ROOM 1151 START--
 Malthera's Abyss
 1146,0,0,1150
-   The floor is uneven, as if the very ground rejects the idea of stability.
- The walls crumble, the ceiling sags-this place is not merely in ruins. It is
- returning to the earth, piece by piece, as if erasing itself from history.
+The floor is uneven, as if the very ground rejects the idea of stability. The walls crumble, the ceiling sags-this place is not merely in ruins. It is returning to the earth, piece by piece, as if erasing itself from history.
 --ROOM 1151 END--
 --ROOM 1152 START--
 Malthera's Chamber
 0,0,0,1143
-   You stands in the middle of her secret chamber, the walls pressing in on
- either side. Before you, as if materializing from the shadows, stands
- Malthera.
+You stands in the middle of her secret chamber, the walls pressing in on either side. Before you, as if materializing from the shadows, stands Malthera.
 --ROOM 1152 END--
 --ROOM 1153 START--
 The Bone Orchard
 1154,0,0,0
-   A thin mist clings to the ground, swirling in the darkness that surrounds
- you.
+A thin mist clings to the ground, swirling in the darkness that surrounds you.
 --ROOM 1153 END--
 --ROOM 1154 START--
 The Bone Orchard
 0,1153,1155,0
-   Silence blankets the world. In the distance, a shadowy structure looms.
+Silence blankets the world. In the distance, a shadowy structure looms.
 --ROOM 1154 END--
 --ROOM 1155 START--
 The Bone Orchard
 1157,0,1156,1154
-   Towering crosses, adorned with the bones of those who perished to create
- them, stand as grim monuments.
+Towering crosses, adorned with the bones of those who perished to create them, stand as grim monuments.
 --ROOM 1155 END--
 --ROOM 1156 START--
 The Bone Orchard
 0,0,0,1155
-   A wall of bone rises before you, its surface adorned with withered,
- crumbling flowers.
+A wall of bone rises before you, its surface adorned with withered, crumbling flowers.
 --ROOM 1156 END--
 --ROOM 1157 START--
 The Bone Orchard
 1158,1155,0,0
-   A void stretches before you, thick with the stench of decay.
+A void stretches before you, thick with the stench of decay.
 --ROOM 1157 END--
 --ROOM 1158 START--
 The Bone Orchard
 0,1157,1165,1159
-   Bone walls loom on either side, smeared with crude paintings-an attempt at a
- story long since forgotten.
+Bone walls loom on either side, smeared with crude paintings-an attempt at a story long since forgotten.
 --ROOM 1158 END--
 --ROOM 1159 START--
 The Bone Orchard
 1160,0,1158,0
-   Statues of creatures long extinct, sculpted from bone, leer at you from the
- shadows.
+Statues of creatures long extinct, sculpted from bone, leer at you from the shadows.
 --ROOM 1159 END--
 --ROOM 1160 START--
 The Bone Orchard
 1161,1159,0,0
-   This place whispers madness, drawing you ever closer to the abyss.
+This place whispers madness, drawing you ever closer to the abyss.
 --ROOM 1160 END--
 --ROOM 1161 START--
 The Bone Orchard
 1164,1160,1162,0
-   A throne room of sorts, constructed from bone and desiccated flesh, looms
- ahead.
+A throne room of sorts, constructed from bone and desiccated flesh, looms ahead.
 --ROOM 1161 END--
 --ROOM 1162 START--
 The Bone Orchard
 1163,0,0,1161
-   Piles of discarded bones lie forgotten, their owners long since erased from
- memory.
+Piles of discarded bones lie forgotten, their owners long since erased from memory.
 --ROOM 1162 END--
 --ROOM 1163 START--
 The Bone Orchard
 0,1162,0,1164
-   A great pot boils over a fire, a pillar of steam rising ominously into the
- air.
+A great pot boils over a fire, a pillar of steam rising ominously into the air.
 --ROOM 1163 END--
 --ROOM 1164 START--
 The Bone Orchard
 0,1161,1163,0
-   A sudden chill crawls up your spine as you wander through the gloom.
+A sudden chill crawls up your spine as you wander through the gloom.
 --ROOM 1164 END--
 --ROOM 1165 START--
 The Bone Orchard
 0,0,1166,1158
-   A staircase, thick with dust and cobwebs, descends into the depths below.
+A staircase, thick with dust and cobwebs, descends into the depths below.
 --ROOM 1165 END--
 --ROOM 1166 START--
 The Bone Orchard
 0,0,1167,1165
-   At the base of the staircase, you stand surrounded by the silent echoes of
- the dead.
+At the base of the staircase, you stand surrounded by the silent echoes of the dead.
 --ROOM 1166 END--
 --ROOM 1167 START--
 The Bone Orchard
 0,1168,0,1166
-   The steady thrum of a drum reverberates through the walls, its rhythm
- unsettling.
+The steady thrum of a drum reverberates through the walls, its rhythm unsettling.
 --ROOM 1167 END--
 --ROOM 1168 START--
 The Bone Orchard
 1167,1169,0,0
-   Distant chanting drifts through the air, wrapping around you like unseen
- hands, tightening with every syllable.
+Distant chanting drifts through the air, wrapping around you like unseen hands, tightening with every syllable.
 --ROOM 1168 END--
 --ROOM 1169 START--
 The Bone Orchard
 1168,1175,1170,0
-   The acrid scent of fire lingers. With each step, a gnawing dread grows
- you're being watched.
+The acrid scent of fire lingers. With each step, a gnawing dread grows you're being watched.
 --ROOM 1169 END--
 --ROOM 1170 START--
 The Bone Orchard
 0,0,1171,1169
-   Pillars of bone, bound together by dried mud, stand as grotesque sentinels.
+Pillars of bone, bound together by dried mud, stand as grotesque sentinels.
 --ROOM 1170 END--
 --ROOM 1171 START--
 The Bone Orchard
 1172,1174,0,1170
-   A towering stone statue looms over a gathering of fervent worshippers.
+A towering stone statue looms over a gathering of fervent worshippers.
 --ROOM 1171 END--
 --ROOM 1172 START--
 The Bone Orchard
 1173,1171,0,0
-   The worshippers dance and sing, their voices lifted in reverence to their
- unseen god.
+The worshippers dance and sing, their voices lifted in reverence to their unseen god.
 --ROOM 1172 END--
 --ROOM 1173 START--
 The Bone Orchard
 0,1172,0,0
-   A desolate expanse of bone and rock stretches before you, a wasteland devoid
- of life.
+A desolate expanse of bone and rock stretches before you, a wasteland devoid of life.
 --ROOM 1173 END--
 --ROOM 1174 START--
 The Bone Orchard
 1171,0,0,0
-   The world is nothing but darkness, endless and unbroken.
+The world is nothing but darkness, endless and unbroken.
 --ROOM 1174 END--
 --ROOM 1175 START--
 The Bone Orchard
 1169,1176,0,0
-   The mist thickens, creeping around you. Laughter echoes from unseen mouths.
+The mist thickens, creeping around you. Laughter echoes from unseen mouths.
 --ROOM 1175 END--
 --ROOM 1176 START--
 The Bone Orchard
 1175,1179,1177,1178
-   People dance around you, their laughter and the scent of wine thick in the
- air.
+People dance around you, their laughter and the scent of wine thick in the air.
 --ROOM 1176 END--
 --ROOM 1177 START--
 The Bone Orchard
 0,0,0,1176
-   Celebration surrounds you, the revelers moving as if caught in an
- enchantment.
+Celebration surrounds you, the revelers moving as if caught in an enchantment.
 --ROOM 1177 END--
 --ROOM 1178 START--
 The Bone Orchard
 0,0,1176,0
-   Laughter and song drift through the void, yet all around you is an endless
- sea of darkness.
+Laughter and song drift through the void, yet all around you is an endless sea of darkness.
 --ROOM 1178 END--
 --ROOM 1179 START--
 The Bone Orchard
 1176,1180,0,0
-   A grand hall, shaped by those who call this hellish place home, rises before
- you.
+A grand hall, shaped by those who call this hellish place home, rises before you.
 --ROOM 1179 END--
 --ROOM 1180 START--
 The Bone Orchard
 1179,1182,0,1181
-   As far as the eye can see, madness stretches across the land.
+As far as the eye can see, madness stretches across the land.
 --ROOM 1180 END--
 --ROOM 1181 START--
 The Bone Orchard
 0,0,1180,0
-   Rows of makeshift beds, cobbled together from whatever could be scavenged,
- fill the space.
+Rows of makeshift beds, cobbled together from whatever could be scavenged, fill the space.
 --ROOM 1181 END--
 --ROOM 1182 START--
 The Bone Orchard
 1180,1184,1183,0
-   The rich aroma of spices fills the air as a chef moves about, lost in their
- craft.
+The rich aroma of spices fills the air as a chef moves about, lost in their craft.
 --ROOM 1182 END--
 --ROOM 1183 START--
 The Bone Orchard
 0,0,1186,1182
-   The pale glow of the moon calls to you, an eerie beacon in the night.
+The pale glow of the moon calls to you, an eerie beacon in the night.
 --ROOM 1183 END--
 --ROOM 1184 START--
 The Bone Orchard
 1182,0,0,1185
-   You follow the winding path, the reflection of moonlight shimmering ahead.
+You follow the winding path, the reflection of moonlight shimmering ahead.
 --ROOM 1184 END--
 --ROOM 1185 START--
 The Bone Orchard
 0,1215,1184,0
-   The scent of perfume lingers as you approach a decaying dock, where an old
- boat sways upon the dark waters.
+The scent of perfume lingers as you approach a decaying dock, where an old boat sways upon the dark waters.
 --ROOM 1185 END--
 --ROOM 1186 START--
 The Pale Lantern Marsh
 0,0,1187,1183
-   The boat drifts lazily through the murky waters, each paddle stroke stirring
- the stagnant air. The thick stench of the swamp clings to your lungs, heavy
- and unshakable.
+The boat drifts lazily through the murky waters, each paddle stroke stirring the stagnant air. The thick stench of the swamp clings to your lungs, heavy and unshakable.
 --ROOM 1186 END--
 --ROOM 1187 START--
 The Pale Lantern Marsh
 1188,0,1197,1186
-   You guide your boat through the reeds, their slender stalks brushing against
- the hull. The water ripples gently as you row, the silence broken only by the
- distant croak of unseen creatures.
+You guide your boat through the reeds, their slender stalks brushing against the hull. The water ripples gently as you row, the silence broken only by the distant croak of unseen creatures.
 --ROOM 1187 END--
 --ROOM 1188 START--
 The Pale Lantern Marsh
 1189,1187,0,0
-   The passage narrows, the shoreline pressing close. From the darkness beyond,
- two glowing yellow eyes pierce the night-watchful, unblinking, unknown.
+The passage narrows, the shoreline pressing close. From the darkness beyond, two glowing yellow eyes pierce the night-watchful, unblinking, unknown.
 --ROOM 1188 END--
 --ROOM 1189 START--
 The Pale Lantern Marsh
 1190,1188,0,0
-   A deafening roar shatters the silence, reverberating through the thick night
- air. The sound grips your chest, running through your very being like a tremor
- of unseen dread.
+A deafening roar shatters the silence, reverberating through the thick night air. The sound grips your chest, running through your very being like a tremor of unseen dread.
 --ROOM 1189 END--
 --ROOM 1190 START--
 The Pale Lantern Marsh
 0,1189,1191,0
-   The moon hangs high, casting a ghostly glow over the landscape. Your lantern
- flickers uncertainly, its feeble light swallowed by the vast darkness.
+The moon hangs high, casting a ghostly glow over the landscape. Your lantern flickers uncertainly, its feeble light swallowed by the vast darkness.
 --ROOM 1190 END--
 --ROOM 1191 START--
 The Pale Lantern Marsh
 0,0,1192,1190
-   From the shoreline, gnarled trees cling desperately to the eroded banks,
- their roots like skeletal fingers grasping at the earth.
+From the shoreline, gnarled trees cling desperately to the eroded banks, their roots like skeletal fingers grasping at the earth.
 --ROOM 1191 END--
 --ROOM 1192 START--
 The Pale Lantern Marsh
 1193,0,0,1191
-   Water slaps gently against the boat, an eerie, rhythmic sound. You row
- onward, each stroke taking you deeper into the unknown.
+Water slaps gently against the boat, an eerie, rhythmic sound. You row onward, each stroke taking you deeper into the unknown.
 --ROOM 1192 END--
 --ROOM 1193 START--
 The Pale Lantern Marsh
 1196,1192,1194,0
-   The dense marsh closes around you, reeds swaying in the wind. Somewhere in
- the darkness, distant calls echo-a language not meant for human ears.
+The dense marsh closes around you, reeds swaying in the wind. Somewhere in the darkness, distant calls echo-a language not meant for human ears.
 --ROOM 1193 END--
 --ROOM 1194 START--
 The Pale Lantern Marsh
 1195,0,0,1193
-   The boat drifts, directionless. You wonder where the water will carry you,
- and whether you'll ever find your way back.
+The boat drifts, directionless. You wonder where the water will carry you, and whether you'll ever find your way back.
 --ROOM 1194 END--
 --ROOM 1195 START--
 The Pale Lantern Marsh
 0,1194,0,1196
-   Your oar drags through the muck, the mud clinging to it like grasping hands.
- In the shadows, something stirs.
+Your oar drags through the muck, the mud clinging to it like grasping hands. In the shadows, something stirs.
 --ROOM 1195 END--
 --ROOM 1196 START--
 The Pale Lantern Marsh
 0,1193,1195,0
-   For a fleeting moment, the lanter's warmth lulls you into a dream-a distant
- memory of a soft bed, a fire, safety. Then the cold night reminds you where
- you are.
+For a fleeting moment, the lanter's warmth lulls you into a dream-a distant memory of a soft bed, a fire, safety. Then the cold night reminds you where you are.
 --ROOM 1196 END--
 --ROOM 1197 START--
 The Pale Lantern Marsh
 0,1207,1198,1187
-   The current tugs at the boat, urging it forward. Ahead, the water forks,
- each path winding into uncertainty.
+The current tugs at the boat, urging it forward. Ahead, the water forks, each path winding into uncertainty.
 --ROOM 1197 END--
 --ROOM 1198 START--
 The Pale Lantern Marsh
 0,0,1199,1197
-   From the water, a dark shape bursts forth, landing on the shore with a heavy
- splash. A massive frog, its bulging eyes reflecting the moonlight, watches you
- in silence.
+From the water, a dark shape bursts forth, landing on the shore with a heavy splash. A massive frog, its bulging eyes reflecting the moonlight, watches you in silence.
 --ROOM 1198 END--
 --ROOM 1199 START--
 The Pale Lantern Marsh
 1206,0,1200,1198
-   The boat drifts dangerously close to a rocky shore. You react quickly,
- shifting course before the jagged stones can claim you.
+The boat drifts dangerously close to a rocky shore. You react quickly, shifting course before the jagged stones can claim you.
 --ROOM 1199 END--
 --ROOM 1200 START--
 The Pale Lantern Marsh
 0,0,1201,1199
-   Through the mist, the skeletal remains of an old house emerge. Its rotting
- frame clings desperately to the earth, long abandoned, yet somehow, waiting.
+Through the mist, the skeletal remains of an old house emerge. Its rotting frame clings desperately to the earth, long abandoned, yet somehow, waiting.
 --ROOM 1200 END--
 --ROOM 1201 START--
 The Pale Lantern Marsh
 1202,0,0,1200
-   The island is a tangle of tall grass, swallowing the landscape in a wild,
- untamed embrace.
+The island is a tangle of tall grass, swallowing the landscape in a wild, untamed embrace.
 --ROOM 1201 END--
 --ROOM 1202 START--
 The Pale Lantern Marsh
 1203,1201,0,0
-   Your oars grow heavy with fatigue, muscles aching. You ease up, letting the
- boat glide as you catch your breath.
+Your oars grow heavy with fatigue, muscles aching. You ease up, letting the boat glide as you catch your breath.
 --ROOM 1202 END--
 --ROOM 1203 START--
 The Pale Lantern Marsh
 0,1202,0,1204
-   The grass sways unnaturally, as though something unseen moves within. You
- are not alone.
+The grass sways unnaturally, as though something unseen moves within. You are not alone.
 --ROOM 1203 END--
 --ROOM 1204 START--
 The Pale Lantern Marsh
 0,0,1203,1205
-   The reeds part as you row, revealing the dark, sprawling landscape beyond an
- expanse of shadow and uncertainty.
+The reeds part as you row, revealing the dark, sprawling landscape beyond an expanse of shadow and uncertainty.
 --ROOM 1204 END--
 --ROOM 1205 START--
 The Pale Lantern Marsh
 0,1206,1204,0
-   Clouds creep across the sky, swallowing the moon. The world dims, leaving
- only the feeble glow of your lantern to push back the dark.
+Clouds creep across the sky, swallowing the moon. The world dims, leaving only the feeble glow of your lantern to push back the dark.
 --ROOM 1205 END--
 --ROOM 1206 START--
 The Pale Lantern Marsh
 1205,1199,0,0
-   A chill runs through you, deeper than the night air. For a moment, it feels
- as though a cold hand has brushed against your soul.
+A chill runs through you, deeper than the night air. For a moment, it feels as though a cold hand has brushed against your soul.
 --ROOM 1206 END--
 --ROOM 1207 START--
 The Pale Lantern Marsh
 1197,1208,0,0
-   With careful effort, you maneuver through a narrow channel. The boat emerges
- into a still pond, the water eerily motionless beneath the starlit sky.
+With careful effort, you maneuver through a narrow channel. The boat emerges into a still pond, the water eerily motionless beneath the starlit sky.
 --ROOM 1207 END--
 --ROOM 1208 START--
 The Pale Lantern Marsh
 1207,0,1209,1210
-   The clouds slowly part, revealing the moon in all its eerie brilliance. The
- landscape is illuminated once more-strange, quiet, expectant.
+The clouds slowly part, revealing the moon in all its eerie brilliance. The landscape is illuminated once more-strange, quiet, expectant.
 --ROOM 1208 END--
 --ROOM 1209 START--
 The Pale Lantern Marsh
 0,0,0,1208
-   You drift, gazing toward the shoreline. Shadows shift, and you can't help
- but wonder what lurks just beyond your sight.
+You drift, gazing toward the shoreline. Shadows shift, and you can't help but wonder what lurks just beyond your sight.
 --ROOM 1209 END--
 --ROOM 1210 START--
 The Pale Lantern Marsh
 0,1211,1208,0
-   Crickets chirp in the moonlight, their song weaving through the night. For a
- moment, a curious sense of whimsy washes over you.
+Crickets chirp in the moonlight, their song weaving through the night. For a moment, a curious sense of whimsy washes over you.
 --ROOM 1210 END--
 --ROOM 1211 START--
 The Pale Lantern Marsh
 1210,1212,0,0
-   The trees fall away as you paddle into open water, a vast expanse of
- nothingness stretching before you. The darkness swallows the horizon.
+The trees fall away as you paddle into open water, a vast expanse of nothingness stretching before you. The darkness swallows the horizon.
 --ROOM 1211 END--
 --ROOM 1212 START--
 The Pale Lantern Marsh
 1211,0,1213,0
-   From the water ahead, a cluster of bubbles disturbs the surface. Something
- stirs beneath.
+From the water ahead, a cluster of bubbles disturbs the surface. Something stirs beneath.
 --ROOM 1212 END--
 --ROOM 1213 START--
 The Pale Lantern Marsh
 0,1214,0,1212
-   A massive frog, its yellow eyes glowing like lanterns, stares at you. It
- seems peaceful, yet something in its gaze holds an ancient knowing.
+A massive frog, its yellow eyes glowing like lanterns, stares at you. It seems peaceful, yet something in its gaze holds an ancient knowing.
 --ROOM 1213 END--
 --ROOM 1214 START--
 The Pale Lantern Marsh
 1213,0,0,0
-   From the depths, she rises-a water fairy, shimmering with an ethereal glow.
- She greets you with a warm, knowing smile, her presence both calming and
- otherworldly.
+From the depths, she rises-a water fairy, shimmering with an ethereal glow. She greets you with a warm, knowing smile, her presence both calming and otherworldly.
 --ROOM 1214 END--
 --ROOM 1215 START--
 The Hollow Reflection Pool
 1185,1216,0,0
-   The oars creak as you row the old boat, each stroke pulling you deeper into
- the unknown.
+The oars creak as you row the old boat, each stroke pulling you deeper into the unknown.
 --ROOM 1215 END--
 --ROOM 1216 START--
 The Hollow Reflection Pool
 1215,0,1217,0
-   An unseen force seizes the boat, dragging it inexorably into the yawning
- mouth of a vast stone tunnel.
+An unseen force seizes the boat, dragging it inexorably into the yawning mouth of a vast stone tunnel.
 --ROOM 1216 END--
 --ROOM 1217 START--
 The Hollow Reflection Pool
 0,1218,0,1216
-   Darkness swallows you whole, the roar of rushing water echoing through
- unseen corridors.
+Darkness swallows you whole, the roar of rushing water echoing through unseen corridors.
 --ROOM 1217 END--
 --ROOM 1218 START--
 The Hollow Reflection Pool
 1217,1219,0,0
-   Your lantern flickers, its feeble light revealing nothing beyond the
- restless waters.
+Your lantern flickers, its feeble light revealing nothing beyond the restless waters.
 --ROOM 1218 END--
 --ROOM 1219 START--
 The Hollow Reflection Pool
 1218,0,1220,0
-   From the void, a dim light stirs-wavering, uncertain-like something
- awakening from a long slumber.
+From the void, a dim light stirs-wavering, uncertain-like something awakening from a long slumber.
 --ROOM 1219 END--
 --ROOM 1220 START--
 The Hollow Reflection Pool
 0,1221,0,1219
-   A spectral figure hovers above the murky water-a young woman, her form
- barely clinging to reality.
+A spectral figure hovers above the murky water-a young woman, her form barely clinging to reality.
 --ROOM 1220 END--
 --ROOM 1221 START--
 The Hollow Reflection Pool
 1220,1222,0,0
-    A piercing scream shatters the silence. In its wake, a face you know-a face
- impossible-emerges, stopping you cold.
+A piercing scream shatters the silence. In its wake, a face you know-a face impossible-emerges, stopping you cold.
 --ROOM 1221 END--
 --ROOM 1222 START--
 The Hollow Reflection Pool
 1221,0,1223,0
-   The boat lurches to a halt. Before you, a stone platform rises from the
- depths, a staircase slick with moss and mystery.
+The boat lurches to a halt. Before you, a stone platform rises from the depths, a staircase slick with moss and mystery.
 --ROOM 1222 END--
 --ROOM 1223 START--
 The Hollow Reflection Pool
 0,1224,0,1222
-   The steps glisten with moisture, tangled in seaweed and decay. A rancid
- stench clings to the air.
+The steps glisten with moisture, tangled in seaweed and decay. A rancid stench clings to the air.
 --ROOM 1223 END--
 --ROOM 1224 START--
 The Hollow Reflection Pool
 1223,0,0,1225
-   Light floods the chamber, unearthly and pure. A voice-ancient, sorrowful
- sings from somewhere just beyond time.
+Light floods the chamber, unearthly and pure. A voice-ancient, sorrowful sings from somewhere just beyond time.
 --ROOM 1224 END--
 --ROOM 1225 START--
 The Hollow Reflection Pool
 0,0,1224,1226
-   A massive bat shrieks past, its wings a blur. Below, a viscous ooze seeps up
- from the stone like something waking from beneath.
+A massive bat shrieks past, its wings a blur. Below, a viscous ooze seeps up from the stone like something waking from beneath.
 --ROOM 1225 END--
 --ROOM 1226 START--
 The Hollow Reflection Pool
 0,1227,1225,0
-   You drift forward, your thoughts fogged, your steps uncertain-as though
- walking through a dream.
+You drift forward, your thoughts fogged, your steps uncertain-as though walking through a dream.
 --ROOM 1226 END--
 --ROOM 1227 START--
 The Hollow Reflection Pool
 1226,1234,0,1228
-   Everything here feels... wrong. Familiar, yet wholly alien, like echoes from
- a world that never was.
+Everything here feels... wrong. Familiar, yet wholly alien, like echoes from a world that never was.
 --ROOM 1227 END--
 --ROOM 1228 START--
 The Hollow Reflection Pool
 0,0,1227,1229
-   Tattered blankets hang limp against the walls-a last remnant of a lost
- civilization, their story long since faded.
+Tattered blankets hang limp against the walls-a last remnant of a lost civilization, their story long since faded.
 --ROOM 1228 END--
 --ROOM 1229 START--
 The Hollow Reflection Pool
 1230,0,1228,0
-   From the blackness, a disembodied head drifts forward, its mouth twisted in
- an endless wail of agony.
+From the blackness, a disembodied head drifts forward, its mouth twisted in an endless wail of agony.
 --ROOM 1229 END--
 --ROOM 1230 START--
 The Hollow Reflection Pool
 1231,1229,0,1233
-   The walls are adorned with painted skulls, their hollow eyes following your
- every move.
+The walls are adorned with painted skulls, their hollow eyes following your every move.
 --ROOM 1230 END--
 --ROOM 1231 START--
 The Hollow Reflection Pool
 0,1230,0,1232
-   You stand at the platform's edge, gazing into the abyss. Distant platforms
- hover in the void, like stepping stones to nowhere.
+You stand at the platform's edge, gazing into the abyss. Distant platforms hover in the void, like stepping stones to nowhere.
 --ROOM 1231 END--
 --ROOM 1232 START--
 The Hollow Reflection Pool
 0,1233,1231,0
-   With each step, water gurgles up through the cracks, as if the very ground
- resents your passage.
+With each step, water gurgles up through the cracks, as if the very ground resents your passage.
 --ROOM 1232 END--
 --ROOM 1233 START--
 The Hollow Reflection Pool
 1232,0,1230,0
-   A shiver runs through you. For a fleeting moment, you sense a presence-a
- shadow just beyond sight.
+A shiver runs through you. For a fleeting moment, you sense a presence-a shadow just beyond sight.
 --ROOM 1233 END--
 --ROOM 1234 START--
 The Hollow Reflection Pool
 1227,1236,1235,0
-   The walls shimmer with inlaid gold and silver, their craftsmanship
- otherworldly, their purpose unknown.
+The walls shimmer with inlaid gold and silver, their craftsmanship otherworldly, their purpose unknown.
 --ROOM 1234 END--
 --ROOM 1235 START--
 The Hollow Reflection Pool
 0,0,1242,1234
-   A narrow passageway coils through the dark, leading ever downward into an
- abyss of endless night.
+A narrow passageway coils through the dark, leading ever downward into an abyss of endless night.
 --ROOM 1235 END--
 --ROOM 1236 START--
 The Hollow Reflection Pool
 1234,0,0,1237
-   A sudden flash of white light blinds you. When your vision clears, you stand
- in a world wholly unlike your own.
+A sudden flash of white light blinds you. When your vision clears, you stand in a world wholly unlike your own.
 --ROOM 1236 END--
 --ROOM 1237 START--
 The Hollow Reflection Pool
 0,1238,1236,0
-   Dust swirls in the air as you stumble into a strange town-wooden buildings,
- horses tethered to worn posts, a place out of time.
+Dust swirls in the air as you stumble into a strange town-wooden buildings, horses tethered to worn posts, a place out of time.
 --ROOM 1237 END--
 --ROOM 1238 START--
 The Hollow Reflection Pool
 1237,1241,0,1239
-   In an instant, the world shifts. Before you, the ruins of a town smolder
- under an unforgiving sun, the glare near blinding.
+In an instant, the world shifts. Before you, the ruins of a town smolder under an unforgiving sun, the glare near blinding.
 --ROOM 1238 END--
 --ROOM 1239 START--
 The Hollow Reflection Pool
 0,1240,1238,0
-   A strange melody drifts from a box perched atop a metallic contraption, its
- tune eerily familiar yet utterly foreign.
+A strange melody drifts from a box perched atop a metallic contraption, its tune eerily familiar yet utterly foreign.
 --ROOM 1239 END--
 --ROOM 1240 START--
 The Hollow Reflection Pool
 1239,0,1241,0
-   Everything here is strange-the people, their vibrant clothes, their
- mannerisms alien yet somehow human.
+Everything here is strange-the people, their vibrant clothes, their mannerisms alien yet somehow human.
 --ROOM 1240 END--
 --ROOM 1241 START--
 The Hollow Reflection Pool
 1238,0,0,1240
-   A chill sweeps over you, and before you can react, blinding light envelops
- your world.
+A chill sweeps over you, and before you can react, blinding light envelops your world.
 --ROOM 1241 END--
 --ROOM 1242 START--
 The Marionette Basilica
 0,0,1243,1235
-   You stand before a grand cathedral, its once-majestic spires now clawing at
- the heavens in silent despair, surrounded by the ruins of a forgotten world.
+You stand before a grand cathedral, its once-majestic spires now clawing at the heavens in silent despair, surrounded by the ruins of a forgotten world.
 --ROOM 1242 END--
 --ROOM 1243 START--
 The Marionette Basilica
 1244,0,0,1242
-   The cathedral's heavy doors hang from their hinges, barely clinging to their
- purpose. An unsettling presence lingers-you are being watched.
+The cathedral's heavy doors hang from their hinges, barely clinging to their purpose. An unsettling presence lingers-you are being watched.
 --ROOM 1243 END--
 --ROOM 1244 START--
 The Marionette Basilica
 0,1243,1245,0
-   Silence presses in from all sides. Your lantern flickers, its feeble glow
- swallowed by the vast darkness, revealing little beyond the cold void.
+Silence presses in from all sides. Your lantern flickers, its feeble glow swallowed by the vast darkness, revealing little beyond the cold void.
 --ROOM 1244 END--
 --ROOM 1245 START--
 The Marionette Basilica
 1246,0,0,1244
-   Dust coats the walls in a thick shroud of neglect. Before you, a small
- fountain stands lifeless, its basin long since abandoned by water.
+Dust coats the walls in a thick shroud of neglect. Before you, a small fountain stands lifeless, its basin long since abandoned by water.
 --ROOM 1245 END--
 --ROOM 1246 START--
 The Marionette Basilica
 1247,1245,0,0
-   You reel back as your eyes settle upon a life-sized doll, its vacant gaze
- locked onto you as if it had been waiting.
+You reel back as your eyes settle upon a life-sized doll, its vacant gaze locked onto you as if it had been waiting.
 --ROOM 1246 END--
 --ROOM 1247 START--
 The Marionette Basilica
 0,1246,1248,0
-   Each step you take sends a chorus of creaks and pops through the rotting
- floorboards, as if the structure itself protests your intrusion.
+Each step you take sends a chorus of creaks and pops through the rotting floorboards, as if the structure itself protests your intrusion.
 --ROOM 1247 END--
 --ROOM 1248 START--
 The Marionette Basilica
 1252,0,1249,1247
-   Towering pillars strain beneath the weight of the cathedral's roof. In
- several places, the ceiling appears moments away from surrendering to time's
- decay.
+Towering pillars strain beneath the weight of the cathedral's roof. In several places, the ceiling appears moments away from surrendering to time's decay.
 --ROOM 1248 END--
 --ROOM 1249 START--
 The Marionette Basilica
 0,1250,0,1248
-   The walls are stripped bare, robbed of any trace of their former grandeur,
- leaving behind only ghostly impressions of what once adorned them.
+The walls are stripped bare, robbed of any trace of their former grandeur, leaving behind only ghostly impressions of what once adorned them.
 --ROOM 1249 END--
 --ROOM 1250 START--
 The Marionette Basilica
 1249,0,1251,0
-   The wind howls through unseen cracks in the ancient walls, whispering
- secrets long since lost to the void.
+The wind howls through unseen cracks in the ancient walls, whispering secrets long since lost to the void.
 --ROOM 1250 END--
 --ROOM 1251 START--
 The Marionette Basilica
 0,0,0,1250
-   A massive, dust-laden window looms before you, gazing out over a vast,
- unknowable expanse.
+A massive, dust-laden window looms before you, gazing out over a vast, unknowable expanse.
 --ROOM 1251 END--
 --ROOM 1252 START--
 The Marionette Basilica
 1253,1248,0,0
-    You stand before a sprawling place of worship. Rows of pews stretch before
- you, each occupied by motionless worshippers.
+You stand before a sprawling place of worship. Rows of pews stretch before you, each occupied by motionless worshippers.
 --ROOM 1252 END--
 --ROOM 1253 START--
 The Marionette Basilica
 1256,1252,1254,1255
-   A profound silence envelops you. You move cautiously, but no sound follows
- not even your own.
+A profound silence envelops you. You move cautiously, but no sound follows not even your own.
 --ROOM 1253 END--
 --ROOM 1254 START--
 The Marionette Basilica
 0,0,0,1253
-   Slowly, you inch forward through the darkness, hands outstretched, desperate
- not to disturb whatever lurks unseen.
+Slowly, you inch forward through the darkness, hands outstretched, desperate not to disturb whatever lurks unseen.
 --ROOM 1254 END--
 --ROOM 1255 START--
 The Marionette Basilica
 0,0,1253,0
-   A sudden thud echoes from behind. You freeze, scanning the shadows, heart
- pounding as you seek the source of the noise.
+A sudden thud echoes from behind. You freeze, scanning the shadows, heart pounding as you seek the source of the noise.
 --ROOM 1255 END--
 --ROOM 1256 START--
 The Marionette Basilica
 1257,1253,0,0
-   From the corner of your eye, something stirs-someone, or something, rising
- from the gloom.
+From the corner of your eye, something stirs-someone, or something, rising from the gloom.
 --ROOM 1256 END--
 --ROOM 1257 START--
 The Marionette Basilica
 1260,1256,1258,1259
-   A shiver runs down your spine. Every inch of this place exudes an unnatural
- dread.
+A shiver runs down your spine. Every inch of this place exudes an unnatural dread.
 --ROOM 1257 END--
 --ROOM 1258 START--
 The Marionette Basilica
 0,0,0,1257
-   The faint shuffle of movement reaches your ears. Before you, a human-sized
- doll stands, its presence unnatural, its posture wrong.
+The faint shuffle of movement reaches your ears. Before you, a human-sized doll stands, its presence unnatural, its posture wrong.
 --ROOM 1258 END--
 --ROOM 1259 START--
 The Marionette Basilica
 0,0,1257,0
-   The figures seated in the pews remain unnervingly still, their attention
- fixed on the objects in their hands. They do not move. They do not breathe.
+The figures seated in the pews remain unnervingly still, their attention fixed on the objects in their hands. They do not move. They do not breathe.
 --ROOM 1259 END--
 --ROOM 1260 START--
 The Marionette Basilica
 1261,1257,0,0
-   Before the pulpit stands a cloaked figure, its face obscured by shadow. It
- does not acknowledge you.
+Before the pulpit stands a cloaked figure, its face obscured by shadow. It does not acknowledge you.
 --ROOM 1260 END--
 --ROOM 1261 START--
 The Marionette Basilica
 0,1260,1262,0
-   Stacks of dolls tower toward the ceiling, their dust-covered faces frozen in
- expressions too alien to be human.
+Stacks of dolls tower toward the ceiling, their dust-covered faces frozen in expressions too alien to be human.
 --ROOM 1261 END--
 --ROOM 1262 START--
 The Marionette Basilica
 1265,0,1263,1261
-   Only silence and darkness greet you here-until, beneath your feet, the floor
- begins to give way.
+Only silence and darkness greet you here-until, beneath your feet, the floor begins to give way.
 --ROOM 1262 END--
 --ROOM 1263 START--
 The Marionette Basilica
 0,0,1266,1262
-   A twisting staircase descends into an abyss of earth and shadow. A frigid
- chill lingers, seeping into your bones.
+A twisting staircase descends into an abyss of earth and shadow. A frigid chill lingers, seeping into your bones.
 --ROOM 1263 END--
 --ROOM 1264 START--
 The Marionette Basilica
 0,0,0,1265
-   A boarded-up door blocks your path, its purpose unclear-was it meant to keep
- something out, or something in?
+A boarded-up door blocks your path, its purpose unclear-was it meant to keep something out, or something in?
 --ROOM 1264 END--
 --ROOM 1265 START--
 The Marionette Basilica
 0,1262,1264,0
-   The walls bear the scars of frantic, deep scratches. Whatever happened here,
- it was desperate.
+The walls bear the scars of frantic, deep scratches. Whatever happened here, it was desperate.
 --ROOM 1265 END--
 --ROOM 1266 START--
 The Tomb of the Unborn King
 0,0,1267,1263
-   The walls shimmer with the luster of polished gold, casting warm reflections
- that dance in the dim light.
+The walls shimmer with the luster of polished gold, casting warm reflections that dance in the dim light.
 --ROOM 1266 END--
 --ROOM 1267 START--
 The Tomb of the Unborn King
 0,1271,1268,1266
-   The golden glow of the walls shifts, deepening into a rich crimson, as if
- stained by time itself.
+The golden glow of the walls shifts, deepening into a rich crimson, as if stained by time itself.
 --ROOM 1267 END--
 --ROOM 1268 START--
 The Tomb of the Unborn King
 1269,0,0,1267
-   A strange, unplaceable scent drifts through the air, carried on an unseen
- wind.
+A strange, unplaceable scent drifts through the air, carried on an unseen wind.
 --ROOM 1268 END--
 --ROOM 1269 START--
 The Tomb of the Unborn King
 1270,1268,0,0
-   From the ceiling, an orb plummets, bouncing once before defying gravity and
- floating weightlessly before you.
+From the ceiling, an orb plummets, bouncing once before defying gravity and floating weightlessly before you.
 --ROOM 1269 END--
 --ROOM 1270 START--
 The Tomb of the Unborn King
 0,1269,0,0
-   You stand at the threshold of an ancient crypt, a sacred place where the
- spirits of the dead are honored.
+You stand at the threshold of an ancient crypt, a sacred place where the spirits of the dead are honored.
 --ROOM 1270 END--
 --ROOM 1271 START--
 The Tomb of the Unborn King
 1267,1272,0,0
-   The walls tremble, then slowly dissolve into nothingness, leaving you
- suspended in an eerie void.
+The walls tremble, then slowly dissolve into nothingness, leaving you suspended in an eerie void.
 --ROOM 1271 END--
 --ROOM 1272 START--
 The Tomb of the Unborn King
 1271,0,1273,0
-   From the distance, the mournful sound of a woman weeping, her sorrow
- carried on the unseen wind.
+From the distance, the mournful sound of a woman weeping, her sorrow carried on the unseen wind.
 --ROOM 1272 END--
 --ROOM 1273 START--
 The Tomb of the Unborn King
 0,0,1274,1272
-   You stand within a vast and regal hall, its grandeur adorned in the colors
- of royalty.
+You stand within a vast and regal hall, its grandeur adorned in the colors of royalty.
 --ROOM 1273 END--
 --ROOM 1274 START--
 The Tomb of the Unborn King
 0,1280,1275,1273
-   At the center of the room, a solemn statue stands watch over an offering
- dish, as if awaiting tribute.
+At the center of the room, a solemn statue stands watch over an offering dish, as if awaiting tribute.
 --ROOM 1274 END--
 --ROOM 1275 START--
 The Tomb of the Unborn King
 0,0,1276,1274
-   With every step you take, an unseen force whispers the weight of mystery
- upon your soul.
+With every step you take, an unseen force whispers the weight of mystery upon your soul.
 --ROOM 1275 END--
 --ROOM 1276 START--
 The Tomb of the Unborn King
 1277,0,0,1275
-   Water begins to rise around your feet, and the ground shifts precariously,
- as if ready to give way at any moment.
+Water begins to rise around your feet, and the ground shifts precariously, as if ready to give way at any moment.
 --ROOM 1276 END--
 --ROOM 1277 START--
 The Tomb of the Unborn King
 1278,1276,0,0
-   The ceiling crumbles, sending cascades of water crashing down around you in
- chaotic splashes.
+The ceiling crumbles, sending cascades of water crashing down around you in chaotic splashes.
 --ROOM 1277 END--
 --ROOM 1278 START--
 The Tomb of the Unborn King
 0,1277,0,1279
-   Without warning, the walls and floor collapse, unveiling a narrow and
- uncertain path ahead.
+Without warning, the walls and floor collapse, unveiling a narrow and uncertain path ahead.
 --ROOM 1278 END--
 --ROOM 1279 START--
 The Tomb of the Unborn King
 0,0,1278,0
-   You have reached a dead end-an empty void stretching into infinity,
- swallowing all but your presence.
+You have reached a dead end-an empty void stretching into infinity, swallowing all but your presence.
 --ROOM 1279 END--
 --ROOM 1280 START--
 The Tomb of the Unborn King
 1274,1281,0,0
-   Before you lies a tunnel, its passage yawning into the unknown, daring you
- to step forward.
+Before you lies a tunnel, its passage yawning into the unknown, daring you to step forward.
 --ROOM 1280 END--
 --ROOM 1281 START--
 The Tomb of the Unborn King
 1280,1282,0,0
-   Thunder rumbles in the distance, each flash of lightning revealing a massive
- stone door adorned with sacred symbols.
+Thunder rumbles in the distance, each flash of lightning revealing a massive stone door adorned with sacred symbols.
 --ROOM 1281 END--
 --ROOM 1282 START--
 The Tomb of the Unborn King
 1281,0,1283,1291
-   The stench of death clings to the air as you stumble upon several bodies
- left to decay in silent neglect.
+The stench of death clings to the air as you stumble upon several bodies left to decay in silent neglect.
 --ROOM 1282 END--
 --ROOM 1283 START--
 The Tomb of the Unborn King
 0,1284,0,1282
-   The walls glisten with a thick, viscous slime, as though nature itself has
- reclaimed this place.
+The walls glisten with a thick, viscous slime, as though nature itself has reclaimed this place.
 --ROOM 1283 END--
 --ROOM 1284 START--
 The Tomb of the Unborn King
 1283,1285,0,0
-   You freeze as the unmistakable cry of a baby echoes through the emptiness,
- though no child is in sight.
+You freeze as the unmistakable cry of a baby echoes through the emptiness, though no child is in sight.
 --ROOM 1284 END--
 --ROOM 1285 START--
 The Tomb of the Unborn King
 1284,0,1286,1288
-   The walls have been torn asunder, leaving behind only tattered remnants of
- faded wallpaper.
+The walls have been torn asunder, leaving behind only tattered remnants of faded wallpaper.
 --ROOM 1285 END--
 --ROOM 1286 START--
 The Tomb of the Unborn King
 0,0,1287,1285
-   The air grows oppressively hot as a grotesque, disfigured ghoul staggers
- forth from the shadows.
+The air grows oppressively hot as a grotesque, disfigured ghoul staggers forth from the shadows.
 --ROOM 1286 END--
 --ROOM 1287 START--
 The Tomb of the Unborn King
 0,0,0,1286
-   A large, unmarked stone vase stands at the very end of the passage, as if
- guarding something unseen.
+A large, unmarked stone vase stands at the very end of the passage, as if guarding something unseen.
 --ROOM 1287 END--
 --ROOM 1288 START--
 The Tomb of the Unborn King
 0,1289,1285,1293
-   From within the walls, enormous eyes emerge, scanning the room with an
- unsettling awareness-until they find you.
+From within the walls, enormous eyes emerge, scanning the room with an unsettling awareness-until they find you.
 --ROOM 1288 END--
 --ROOM 1289 START--
 The Tomb of the Unborn King
 1288,1290,0,0
-   The red wooden walls are adorned with exquisite tapestries, their origins
- lost to time.
+The red wooden walls are adorned with exquisite tapestries, their origins lost to time.
 --ROOM 1289 END--
 --ROOM 1290 START--
 The Tomb of the Unborn King
 1289,1297,0,0
-   Before you stands a young peasant woman. She offers a gentle smile in
- greeting.
+Before you stands a young peasant woman. She offers a gentle smile in greeting.
 --ROOM 1290 END--
 --ROOM 1291 START--
 The Tomb of the Unborn King
 0,1292,1282,0
-   A fleeting figure-a child, giggling-darts across the room, vanishing as
- quickly as she appeared.
+A fleeting figure-a child, giggling-darts across the room, vanishing as quickly as she appeared.
 --ROOM 1291 END--
 --ROOM 1292 START--
 The Tomb of the Unborn King
 1291,1293,0,1294
-   Reality wavers as everything around you flickers into darkness, only to
- return in irregular pulses.
+Reality wavers as everything around you flickers into darkness, only to return in irregular pulses.
 --ROOM 1292 END--
 --ROOM 1293 START--
 The Tomb of the Unborn King
 1292,0,1288,0
-   The floor is littered with children's toys, but as you approach, they fade
- into nothingness.
+The floor is littered with children's toys, but as you approach, they fade into nothingness.
 --ROOM 1293 END--
 --ROOM 1294 START--
 The Tomb of the Unborn King
 0,0,1292,1295
-   Every inch of the walls is lined with mirrors, each one veiled beneath
- sheets of peculiar colors.
+Every inch of the walls is lined with mirrors, each one veiled beneath sheets of peculiar colors.
 --ROOM 1294 END--
 --ROOM 1295 START--
 The Tomb of the Unborn King
 0,1296,1294,0
-   Portraits hang in perfect rows, their surfaces pristine-untouched by time or
- dust.
+Portraits hang in perfect rows, their surfaces pristine-untouched by time or dust.
 --ROOM 1295 END--
 --ROOM 1296 START--
 The Tomb of the Unborn King
 1295,0,0,0
-   The wall before you is stained with blood, its foul odor thick and cloying
- in the stagnant air.
+The wall before you is stained with blood, its foul odor thick and cloying in the stagnant air.
 --ROOM 1296 END--
 --ROOM 1297 START--
 The Unmade Village
 1290,1298,0,0
-   You stand once more before the entrance to the village of Oathmore, its
- silence heavier than before.
+You stand once more before the entrance to the village of Oathmore, its silence heavier than before.
 --ROOM 1297 END--
 --ROOM 1298 START--
 The Unmade Village
 1297,1299,0,0
-   Everything feels subtly wrong, as if you've stepped into a fractured
- reality. The air hums with an unspoken tension.
+Everything feels subtly wrong, as if you've stepped into a fractured reality. The air hums with an unspoken tension.
 --ROOM 1298 END--
 --ROOM 1299 START--
 The Unmade Village
 1298,1300,0,0
-   Darkened homes with windows blacked out and doors firmly shut, as though the
- village itself is holding its breath.
+Darkened homes with windows blacked out and doors firmly shut, as though the village itself is holding its breath.
 --ROOM 1299 END--
 --ROOM 1300 START--
 The Unmade Village
 1299,1301,0,0
-   In the distance, a green light pulses at steady intervals, almost as if it
- is beckoning you.
+In the distance, a green light pulses at steady intervals, almost as if it is beckoning you.
 --ROOM 1300 END--
 --ROOM 1301 START--
 The Unmade Village
 1300,1304,1302,1303
-   You arrive at a crossroads you swear wasn't here before. The paths ahead
- stretch into uncertainty.
+You arrive at a crossroads you swear wasn't here before. The paths ahead stretch into uncertainty.
 --ROOM 1301 END--
 --ROOM 1302 START--
 The Unmade Village
 0,0,0,1301
-   Beyond lies an endless void, a sea of nothingness. What stirs within its
- depths is left to the imagination.
+Beyond lies an endless void, a sea of nothingness. What stirs within its depths is left to the imagination.
 --ROOM 1302 END--
 --ROOM 1303 START--
 The Unmade Village
 0,0,1301,0
-   You stand at the threshold of a doorway, gazing into an abyss where sound
- and sight cease to exist.
+You stand at the threshold of a doorway, gazing into an abyss where sound and sight cease to exist.
 --ROOM 1303 END--
 --ROOM 1304 START--
 The Unmade Village
 1301,1305,0,0
-   Buildings loom around you, flickering in and out of existence, as though
- reality itself is unraveling.
+Buildings loom around you, flickering in and out of existence, as though reality itself is unraveling.
 --ROOM 1304 END--
 --ROOM 1305 START--
 The Unmade Village
 1304,0,1306,1321
-   The ground trembles beneath your feet. The buildings shift and twist,
- reshaping the village before your very eyes.
+The ground trembles beneath your feet. The buildings shift and twist, reshaping the village before your very eyes.
 --ROOM 1305 END--
 --ROOM 1306 START--
 The Unmade Village
 0,0,1307,1305
-   A creeping darkness engulfs the sky. In mere moments, you are swallowed by
- an impenetrable void.
+A creeping darkness engulfs the sky. In mere moments, you are swallowed by an impenetrable void.
 --ROOM 1306 END--
 --ROOM 1307 START--
 The Unmade Village
 0,1308,0,1306
-   The murmur of unseen voices drifts through the air-conversations, footsteps
- yet the streets remain eerily empty.
+The murmur of unseen voices drifts through the air-conversations, footsteps yet the streets remain eerily empty.
 --ROOM 1307 END--
 --ROOM 1308 START--
 The Unmade Village
 1307,1309,0,0
-   A cool breeze whispers down the abandoned village road, carrying with it the
- scent of something long forgotten.
+A cool breeze whispers down the abandoned village road, carrying with it the scent of something long forgotten.
 --ROOM 1308 END--
 --ROOM 1309 START--
 The Unmade Village
 1308,1310,0,0
-   An imposing church stands before you, its entrance gaping like the mouth of
- a long-dead god.
+An imposing church stands before you, its entrance gaping like the mouth of a long-dead god.
 --ROOM 1309 END--
 --ROOM 1310 START--
 The Unmade Village
 1309,0,0,1311
-   You step cautiously into the abandoned place of worship, each movement an
- effort to remain unseen.
+You step cautiously into the abandoned place of worship, each movement an effort to remain unseen.
 --ROOM 1310 END--
 --ROOM 1311 START--
 The Unmade Village
 0,1312,1310,0
-   Lantern held high, you squeeze through a narrow passageway, its walls
- pressing in like silent sentinels.
+Lantern held high, you squeeze through a narrow passageway, its walls pressing in like silent sentinels.
 --ROOM 1311 END--
 --ROOM 1312 START--
 The Unmade Village
 1311,0,0,1313
-   Empty shelves line the walls, long since picked clean. Whatever was once
- here is now only a memory.
+Empty shelves line the walls, long since picked clean. Whatever was once here is now only a memory.
 --ROOM 1312 END--
 --ROOM 1313 START--
 The Unmade Village
 1314,1322,1312,1315
-   The room is stripped to its bare bones, save for the lingering aroma of
- something indefinably strange.
+The room is stripped to its bare bones, save for the lingering aroma of something indefinably strange.
 --ROOM 1313 END--
 --ROOM 1314 START--
 The Ventureweaver's Lair
 0,1313,0,0
-   Behind an ancient wooden desk, The Ventureweaver sits, his fingers resting
- upon a relic of another era-a timeworn laptop running QBasic, with a notepad
- by his side.
+Behind an ancient wooden desk, The Ventureweaver sits, his fingers resting upon a relic of another era-a timeworn laptop running QBasic, with a notepad by his side.
 --ROOM 1314 END--
 --ROOM 1315 START--
 The Unmade Village
 1316,0,1313,0
-   The walls dissolve around you, revealing a breathtaking valley-untouched,
- timeless, and impossibly serene.
+The walls dissolve around you, revealing a breathtaking valley-untouched, timeless, and impossibly serene.
 --ROOM 1315 END--
 --ROOM 1316 START--
 The Unmade Village
 0,1315,0,1317
-   Something about this place feels, wrong. Hollow. Artificial. As though it
- was constructed rather than born.
+Something about this place feels, wrong. Hollow. Artificial. As though it was constructed rather than born.
 --ROOM 1316 END--
 --ROOM 1317 START--
 The Unmade Village
 1318,0,1316,0
-   The flickering glow of your lantern sends shadows writhing across the walls
- and floor, like spirits caught between worlds.
+The flickering glow of your lantern sends shadows writhing across the walls and floor, like spirits caught between worlds.
 --ROOM 1317 END--
 --ROOM 1318 START--
 The Unmade Village
 1319,1317,0,0
-   The towering wooden doors of the old church loom before you, their worn
- surfaces whispering of forgotten prayers.
+The towering wooden doors of the old church loom before you, their worn surfaces whispering of forgotten prayers.
 --ROOM 1318 END--
 --ROOM 1319 START--
 The Unmade Village
 1320,1318,0,0
-   A narrow alleyway stretches into the darkness, utterly barren-not even the
- remnants of past lives disturb its emptiness.
+A narrow alleyway stretches into the darkness, utterly barren-not even the remnants of past lives disturb its emptiness.
 --ROOM 1319 END--
 --ROOM 1320 START--
 The Unmade Village
 0,1319,1321,0
-    Above the rooftops, fragments of land drift aimlessly through the air, as
- though the world itself is searching for completion.
+Above the rooftops, fragments of land drift aimlessly through the air, as though the world itself is searching for completion.
 --ROOM 1320 END--
 --ROOM 1321 START--
 The Unmade Village
 0,0,1305,1320
-   This place bears no mark of human touch. It stands untouched, as if shaped
- by unseen forces beyond mortal comprehension.
+This place bears no mark of human touch. It stands untouched, as if shaped by unseen forces beyond mortal comprehension.
 --ROOM 1321 END--
 --ROOM 1322 START--
 The Clockmaker's Grave
 1313,1323,0,0
-   The relentless ticking of unseen clocks fills the air, while the walls shift
- and turn-great interlocking gears grinding in ceaseless motion.
+The relentless ticking of unseen clocks fills the air, while the walls shift and turn-great interlocking gears grinding in ceaseless motion.
 --ROOM 1322 END--
 --ROOM 1323 START--
 The Clockmaker's Grave
 1322,0,1324,0
-   With each step, a growing unease settles over you, as if the very ground
- beneath your feet resents your presence.
+With each step, a growing unease settles over you, as if the very ground beneath your feet resents your presence.
 --ROOM 1323 END--
 --ROOM 1324 START--
 The Clockmaker's Grave
 0,1325,0,1323
-   Pendulums swing in eerie synchronization, their aged brass components moving
- with an uncanny vitality, almost as if they breathe.
+Pendulums swing in eerie synchronization, their aged brass components moving with an uncanny vitality, almost as if they breathe.
 --ROOM 1324 END--
 --ROOM 1325 START--
 The Clockmaker's Grave
 1324,1326,0,0
-   Strange orbs drift through the air, pulsing with unnatural light. Their
- flickering glow paints the walls in alien patterns.
+Strange orbs drift through the air, pulsing with unnatural light. Their flickering glow paints the walls in alien patterns.
 --ROOM 1325 END--
 --ROOM 1326 START--
 The Clockmaker's Grave
 1325,1327,0,0
-   Time asserts itself in countless ticking voices. Every surface is lined with
- ancient clocks, their hands crawling forward in cruel unity.
+Time asserts itself in countless ticking voices. Every surface is lined with ancient clocks, their hands crawling forward in cruel unity.
 --ROOM 1326 END--
 --ROOM 1327 START--
 The Clockmaker's Grave
 1326,0,1328,0
-   From the walls, mechanical arms emerge-grasping, reaching-fingers twitching
- in a frantic search for something, perhaps you.
+From the walls, mechanical arms emerge-grasping, reaching-fingers twitching in a frantic search for something, perhaps you.
 --ROOM 1327 END--
 --ROOM 1328 START--
 The Clockmaker's Grave
 0,0,1329,1327
-   The floor beneath you shrinks away, revealing a dizzying void below, where
- scattered pinpricks of light shimmer like distant stars.
+The floor beneath you shrinks away, revealing a dizzying void below, where scattered pinpricks of light shimmer like distant stars.
 --ROOM 1328 END--
 --ROOM 1329 START--
 The Clockmaker's Grave
 1330,1331,0,1328
-   Far ahead, beyond the oppressive strangeness of this place, lies a quiet
- refuge-a sanctuary, or perhaps only an illusion of one.
+Far ahead, beyond the oppressive strangeness of this place, lies a quiet refuge-a sanctuary, or perhaps only an illusion of one.
 --ROOM 1329 END--
 --ROOM 1330 START--
 The Clockmaker's Grave
 0,1329,0,0
-   The air thickens, pressing against you like the weight of the earth itself.
- You feel buried in a place where time and space collapse inward.
+The air thickens, pressing against you like the weight of the earth itself. You feel buried in a place where time and space collapse inward.
 --ROOM 1330 END--
 --ROOM 1331 START--
 The Clockmaker's Grave
 1329,1332,0,0
-   You wander through a field of forgotten graves, crude wooden markers jutting
- from the earth-testaments to nameless souls long lost.
+You wander through a field of forgotten graves, crude wooden markers jutting from the earth-testaments to nameless souls long lost.
 --ROOM 1331 END--
 --ROOM 1332 START--
 The Clockmaker's Grave
 1331,0,1333,0
-   The world around you fades to lifeless gray, drained of warmth, motion, and
- time.
+The world around you fades to lifeless gray, drained of warmth, motion, and time.
 --ROOM 1332 END--
 --ROOM 1333 START--
 The Clockmaker's Grave
 0,1334,0,1332
-   Before you looms the mausoleum of the Clockmaker, its weathered stonework
- whispering of forgotten craftsmanship.
+Before you looms the mausoleum of the Clockmaker, its weathered stonework whispering of forgotten craftsmanship.
 --ROOM 1333 END--
 --ROOM 1334 START--
 The Clockmaker's Grave
 1333,0,1335,0
-   Row upon row of coffins rest in solemn stillness, their occupants long past
- the need for time.
+Row upon row of coffins rest in solemn stillness, their occupants long past the need for time.
 --ROOM 1334 END--
 --ROOM 1335 START--
 The Clockmaker's Grave
 0,1336,0,1334
-   A stairwell descends into shadow, its depths promising only the unknown.
+A stairwell descends into shadow, its depths promising only the unknown.
 --ROOM 1335 END--
 --ROOM 1336 START--
 The Clockmaker's Grave
 1335,1337,0,0
-   You cross the threshold into an empty realm. The walls are bare, the air
- stagnant. Beyond, only darkness.
+You cross the threshold into an empty realm. The walls are bare, the air stagnant. Beyond, only darkness.
 --ROOM 1336 END--
 --ROOM 1337 START--
 The Clockmaker's Grave
 1336,1339,0,1338
-   A sea of people churns around you-a bustling market alive with voices,
- movement, and the scent of mechanical oil and old brass.
+A sea of people churns around you-a bustling market alive with voices, movement, and the scent of mechanical oil and old brass.
 --ROOM 1337 END--
 --ROOM 1338 START--
 The Clockmaker's Grave
 0,0,1337,0
-   For a brief moment, you break free from the tide of bodies, finding solace
- in a quiet, forgotten corner.
+For a brief moment, you break free from the tide of bodies, finding solace in a quiet, forgotten corner.
 --ROOM 1338 END--
 --ROOM 1339 START--
 The Clockmaker's Grave
 1337,0,0,1340
-   Clinging to sanity, you press forward through the mass of shifting bodies. A
- voice rises above the din, addressing the crowd with fervor.
+Clinging to sanity, you press forward through the mass of shifting bodies. A voice rises above the din, addressing the crowd with fervor.
 --ROOM 1339 END--
 --ROOM 1340 START--
 The Clockmaker's Grave
 0,0,1339,1341
-   Standing atop a wooden crate, an elderly machinist commands the crowd's rapt
- attention, his words shaping the very air.
+Standing atop a wooden crate, an elderly machinist commands the crowd's rapt attention, his words shaping the very air.
 --ROOM 1340 END--
 --ROOM 1341 START--
 The Clockmaker's Grave
 0,1342,1340,0
-   You push through the throng, emerging into a narrow alleyway-silent, empty,
- untouched by the chaos behind you.
+You push through the throng, emerging into a narrow alleyway-silent, empty, untouched by the chaos behind you.
 --ROOM 1341 END--
 --ROOM 1342 START--
 The Clockmaker's Grave
 1341,1344,1343,0
-   The alley is devoid of life, yet the distant murmur of the crowd lingers,
- just beyond reach.
+The alley is devoid of life, yet the distant murmur of the crowd lingers, just beyond reach.
 --ROOM 1342 END--
 --ROOM 1343 START--
 The Clockmaker's Grave
 0,0,0,1342
-   Tucked away in the dust and grime, a forgotten pile of rusted gears rests-a
- relic of something long dismantled.
+Tucked away in the dust and grime, a forgotten pile of rusted gears rests-a relic of something long dismantled.
 --ROOM 1343 END--
 --ROOM 1344 START--
 The Clockmaker's Grave
 1342,1346,0,1345
-   The grinding of gears fills the air. From the darkness, a cleaning woman
- steps forth, her expression unreadable.
+The grinding of gears fills the air. From the darkness, a cleaning woman steps forth, her expression unreadable.
 --ROOM 1344 END--
 --ROOM 1345 START--
 The Clockmaker's Grave
 0,0,1344,0
-   The floors gleam, scrubbed of dust and decay. Every trace of neglect has
- been meticulously erased.
+The floors gleam, scrubbed of dust and decay. Every trace of neglect has been meticulously erased.
 --ROOM 1345 END--
 --ROOM 1346 START--
 The Clockmaker's Grave
 1344,1348,1347,0
-   Heat rises in thick waves, and somewhere beyond the walls, music drifts
- through the oppressive air.
+Heat rises in thick waves, and somewhere beyond the walls, music drifts through the oppressive air.
 --ROOM 1346 END--
 --ROOM 1347 START--
 The Clockmaker's Grave
 0,0,1351,1346
-   An old wooden door stands before you, its surface worn smooth by time.
- Whatever lies beyond remains a mystery.
+An old wooden door stands before you, its surface worn smooth by time. Whatever lies beyond remains a mystery.
 --ROOM 1347 END--
 --ROOM 1348 START--
 The Clockmaker's Grave
 1346,1350,0,1349
-   Heat seeps from the sewers below. Shadows flicker along the walls-shapeless
- figures that call this place home.
+Heat seeps from the sewers below. Shadows flicker along the walls-shapeless figures that call this place home.
 --ROOM 1348 END--
 --ROOM 1349 START--
 The Clockmaker's Grave
 0,0,1348,0
-   A woman dances through the dim glow, lost in her own rhythm, oblivious to
- the world around her.
+A woman dances through the dim glow, lost in her own rhythm, oblivious to the world around her.
 --ROOM 1349 END--
 --ROOM 1350 START--
 The Clockmaker's Grave
 1348,0,0,0
-   Within the confines of a makeshift hut, an old woman rocks gently in her
- chair, watching the world with knowing eyes.
+Within the confines of a makeshift hut, an old woman rocks gently in her chair, watching the world with knowing eyes.
 --ROOM 1350 END--
 --ROOM 1351 START--
 The Hollow Feast
 0,0,1352,1347
-   You stand before a grand dining hall, where flickering candlelight dances
- across the stone walls. The rich aroma of roasted meat lingers in the air,
- stirring something primal within you.
+You stand before a grand dining hall, where flickering candlelight dances across the stone walls. The rich aroma of roasted meat lingers in the air, stirring something primal within you.
 --ROOM 1351 END--
 --ROOM 1352 START--
 The Hollow Feast
 0,0,1353,1351
-   Rows of wooden tables and benches stretch before you, their worn surfaces
- etched with the echoes of countless feasts. A strange anticipation settles in
- your bones what awaits you here?
+Rows of wooden tables and benches stretch before you, their worn surfaces etched with the echoes of countless feasts. A strange anticipation settles in your bones what awaits you here?
 --ROOM 1352 END--
 --ROOM 1353 START--
 The Hollow Feast
 1355,0,1354,1352
-   A rare tranquility fills this space. The burdens of your journey momentarily
- fade, as if this room itself shields you from the trials beyond.
+A rare tranquility fills this space. The burdens of your journey momentarily fade, as if this room itself shields you from the trials beyond.
 --ROOM 1353 END--
 --ROOM 1354 START--
 The Hollow Feast
 0,0,0,1353
-   You gaze out over an expanse of impossibly black water, its surface
- unnervingly still. A quiet unease settles in your chest.
+You gaze out over an expanse of impossibly black water, its surface unnervingly still. A quiet unease settles in your chest.
 --ROOM 1354 END--
 --ROOM 1355 START--
 The Hollow Feast
 1356,1353,0,0
-   A flurry of motion-chefs work feverishly, their hands a blur as they prepare
- an unending feast. The scent of spice and seared flesh fills the air.
+A flurry of motion-chefs work feverishly, their hands a blur as they prepare an unending feast. The scent of spice and seared flesh fills the air.
 --ROOM 1355 END--
 --ROOM 1356 START--
 The Hollow Feast
 0,1355,1357,0
-   A long line of figures stands, plates in hand, eyes filled with hunger and
- expectation. The steady clatter of utensils and murmured conversations create
- a rhythmic backdrop.
+A long line of figures stands, plates in hand, eyes filled with hunger and expectation. The steady clatter of utensils and murmured conversations create a rhythmic backdrop.
 --ROOM 1356 END--
 --ROOM 1357 START--
 The Hollow Feast
 1358,0,0,1356
-   The mouthwatering aroma of roast beef and carrots drifts through the room,
- teasing your senses. Your stomach clenches with sudden hunger.
+The mouthwatering aroma of roast beef and carrots drifts through the room, teasing your senses. Your stomach clenches with sudden hunger.
 --ROOM 1357 END--
 --ROOM 1358 START--
 The Hollow Feast
 1359,1357,0,0
-   You weave through a sea of people engaged in deep conversation, their voices
- a layered symphony of secrets and stories. The great feast unfolds around you.
+You weave through a sea of people engaged in deep conversation, their voices a layered symphony of secrets and stories. The great feast unfolds around you.
 --ROOM 1358 END--
 --ROOM 1359 START--
 The Hollow Feast
 0,1358,1360,0
-   You push past a heavy swinging door and step into a dimly lit chamber. A
- hunched butcher, his hands slick with blood, greets you with a toothless grin
- as he carves thick slabs of meat.
+You push past a heavy swinging door and step into a dimly lit chamber. A hunched butcher, his hands slick with blood, greets you with a toothless grin as he carves thick slabs of meat.
 --ROOM 1359 END--
 --ROOM 1360 START--
 The Hollow Feast
 1362,0,1361,1359
-   An unsettling presence lingers in the air. Though no eyes meet yours, you
- cannot shake the feeling that something unseen watches your every move.
+An unsettling presence lingers in the air. Though no eyes meet yours, you cannot shake the feeling that something unseen watches your every move.
 --ROOM 1360 END--
 --ROOM 1361 START--
 The Hollow Feast
 0,0,0,1360
-   Rusting meat hooks dangle from the rafters, casting jagged shadows against
- the cold brick wall. The silence here feels oppressive.
+Rusting meat hooks dangle from the rafters, casting jagged shadows against the cold brick wall. The silence here feels oppressive.
 --ROOM 1361 END--
 --ROOM 1362 START--
 The Hollow Feast
 1363,1360,0,0
-   A narrow passage stretches ahead, its walls damp and uninviting. The single
- flickering torch barely holds back the suffocating darkness.
+A narrow passage stretches ahead, its walls damp and uninviting. The single flickering torch barely holds back the suffocating darkness.
 --ROOM 1362 END--
 --ROOM 1363 START--
 The Hollow Feast
 1364,1362,0,1369
-   With a soft rumble, the wall shifts aside, revealing a hidden tavern. The
- warmth of lantern light spills into the gloom, offering refuge from the world
- beyond.
+With a soft rumble, the wall shifts aside, revealing a hidden tavern. The warmth of lantern light spills into the gloom, offering refuge from the world beyond.
 --ROOM 1363 END--
 --ROOM 1364 START--
 The Hollow Feast
 0,1363,1365,0
-   Dim light flickers over wooden tables, where joyous souls revel in drink and
- laughter. The air carries the scent of spilled ale and old stories.
+Dim light flickers over wooden tables, where joyous souls revel in drink and laughter. The air carries the scent of spilled ale and old stories.
 --ROOM 1364 END--
 --ROOM 1365 START--
 The Hollow Feast
 1366,0,0,1364
-   A drunken cook bellows a tune in his native tongue, his voice weaving
- through the lively music that fills the room. The melody is strangely
- haunting.
+A drunken cook bellows a tune in his native tongue, his voice weaving through the lively music that fills the room. The melody is strangely haunting.
 --ROOM 1365 END--
 --ROOM 1366 START--
 The Hollow Feast
 1367,1365,0,0
-   A stone staircase winds downward, its steps vanishing into the darkness of
- the basement below. A faint, musty scent drifts up from the depths.
+A stone staircase winds downward, its steps vanishing into the darkness of the basement below. A faint, musty scent drifts up from the depths.
 --ROOM 1366 END--
 --ROOM 1367 START--
 The Hollow Feast
 0,1366,1368,0
-   Before you, a gaping cave mouth is carved into the stone wall, its entrance
- yawning like the maw of some forgotten beast.
+Before you, a gaping cave mouth is carved into the stone wall, its entrance yawning like the maw of some forgotten beast.
 --ROOM 1367 END--
 --ROOM 1368 START--
 The Hollow Feast
 0,0,1380,1367
-   Water swirls around your ankles, creeping higher with each hesitant step.
- The unknown beckons, its embrace cold and merciless.
+Water swirls around your ankles, creeping higher with each hesitant step. The unknown beckons, its embrace cold and merciless.
 --ROOM 1368 END--
 --ROOM 1369 START--
 The Hollow Feast
 0,0,1363,1370
-   Distant screams slice through the silence. The sound is neither near nor
- far, but it carries with it the weight of something truly dreadful.
+Distant screams slice through the silence. The sound is neither near nor far, but it carries with it the weight of something truly dreadful.
 --ROOM 1369 END--
 --ROOM 1370 START--
 The Hollow Feast
 1371,0,1369,0
-   Rows of rusted meat hooks sway gently from the rafters. A foul, putrid
- stench clings to the air, turning your stomach.
+Rows of rusted meat hooks sway gently from the rafters. A foul, putrid stench clings to the air, turning your stomach.
 --ROOM 1370 END--
 --ROOM 1371 START--
 The Hollow Feast
 1372,1370,0,0
-   Water drips from the ceiling, its rhythmic patter echoing through the
- chamber. Pools of stagnant liquid reflect the dim light.
+Water drips from the ceiling, its rhythmic patter echoing through the chamber. Pools of stagnant liquid reflect the dim light.
 --ROOM 1371 END--
 --ROOM 1372 START--
 The Hollow Feast
 0,1371,1373,1379
-   A cramped storage room, its corners thick with shadow. The air is heavy with
- the scent of damp wood and decay.
+A cramped storage room, its corners thick with shadow. The air is heavy with the scent of damp wood and decay.
 --ROOM 1372 END--
 --ROOM 1373 START--
 The Hollow Feast
 1374,0,0,1372
-   A chill slithers down your spine as you step further into this place. The
- very walls seem to breathe around you.
+A chill slithers down your spine as you step further into this place. The very walls seem to breathe around you.
 --ROOM 1373 END--
 --ROOM 1374 START--
 The Hollow Feast
 1375,1373,0,0
-   You stumble forward, your foot catching on something. Suspended in the
- center of the room, a massive, lifeless beast sways gently-its empty eyes
- locked onto yours.
+You stumble forward, your foot catching on something. Suspended in the center of the room, a massive, lifeless beast sways gently-its empty eyes locked onto yours.
 --ROOM 1374 END--
 --ROOM 1375 START--
 The Hollow Feast
 0,1374,0,1376
-   A lone figure stands, draped in bloodstained white. Their voice, hollow and
- unwavering, declares, I speak for the dead.
+A lone figure stands, draped in bloodstained white. Their voice, hollow and unwavering, declares, I speak for the dead.
 --ROOM 1375 END--
 --ROOM 1376 START--
 The Hollow Feast
 0,0,1375,1377
-   The ground trembles beneath your feet, as though an unseen force is stirring
- from its long slumber.
+The ground trembles beneath your feet, as though an unseen force is stirring from its long slumber.
 --ROOM 1376 END--
 --ROOM 1377 START--
 The Hollow Feast
 0,1378,1376,0
-   Neatly stacked piles of dried animal remains line the floor, their brittle
- forms preserved in eerie precision.
+Neatly stacked piles of dried animal remains line the floor, their brittle forms preserved in eerie precision.
 --ROOM 1377 END--
 --ROOM 1378 START--
 The Hollow Feast
 1377,1379,0,0
-   Portraits lean against the walls, their faces eerily lifelike, as if they
- had only just been placed there. The painted eyes seem to follow you.
+Portraits lean against the walls, their faces eerily lifelike, as if they had only just been placed there. The painted eyes seem to follow you.
 --ROOM 1378 END--
 --ROOM 1379 START--
 The Hollow Feast
 1378,0,1372,0
-   In the corner, a makeshift altar rises from the dust. The air is thick with
- the droning hum of flies, circling their unseen prize.
+In the corner, a makeshift altar rises from the dust. The air is thick with the droning hum of flies, circling their unseen prize.
 --ROOM 1379 END--
 --ROOM 1380 START--
 The Sinking Colonnade
 0,0,1381,1368
-   The flickering lantern casts trembling shadows, revealing only glimpses of
- the encroaching darkness that surrounds you.
+The flickering lantern casts trembling shadows, revealing only glimpses of the encroaching darkness that surrounds you.
 --ROOM 1380 END--
 --ROOM 1381 START--
 The Sinking Colonnade
 0,1382,0,1380
-   You wade through an endless pool of black water, its surface reflecting
- nothing but void.
+You wade through an endless pool of black water, its surface reflecting nothing but void.
 --ROOM 1381 END--
 --ROOM 1382 START--
 The Sinking Colonnade
 1381,0,1383,0
-   Each step feels perilous, the slick ground treacherous beneath your feet. A
- strange, rancid stench clings to the air.
+Each step feels perilous, the slick ground treacherous beneath your feet. A strange, rancid stench clings to the air.
 --ROOM 1382 END--
 --ROOM 1383 START--
 The Sinking Colonnade
 0,1384,0,1382
-   Finely carved pillars rise from the depths, their surfaces slick with a
- strange green film-evidence of shifting water levels over untold ages.
+Finely carved pillars rise from the depths, their surfaces slick with a strange green film-evidence of shifting water levels over untold ages.
 --ROOM 1383 END--
 --ROOM 1384 START--
 The Sinking Colonnade
 1383,1385,0,0
-   You freeze as a sound ripples through the darkness-something unseen rising
- from the water.
+You freeze as a sound ripples through the darkness-something unseen rising from the water.
 --ROOM 1384 END--
 --ROOM 1385 START--
 The Sinking Colonnade
 1384,0,1386,0
-   Your fingers tighten around your sword's hilt as your eyes dart about,
- searching the gloom for unseen threats.
+Your fingers tighten around your sword's hilt as your eyes dart about, searching the gloom for unseen threats.
 --ROOM 1385 END--
 --ROOM 1386 START--
 The Sinking Colonnade
 0,1387,1392,1385
-   In the distance, the sound of rushing water echoes, its source unseen yet
- ominously present.
+In the distance, the sound of rushing water echoes, its source unseen yet ominously present.
 --ROOM 1386 END--
 --ROOM 1387 START--
 The Sinking Colonnade
 1386,1388,0,0
-   The twisting corridors of this forgotten crypt gnaw at your sanity, each
- turn disorienting and unfamiliar.
+The twisting corridors of this forgotten crypt gnaw at your sanity, each turn disorienting and unfamiliar.
 --ROOM 1387 END--
 --ROOM 1388 START--
 The Sinking Colonnade
 1387,1389,0,1391
-   A narrow staircase winds upward toward a crumbling platform, its steps slick
- with moisture.
+A narrow staircase winds upward toward a crumbling platform, its steps slick with moisture.
 --ROOM 1388 END--
 --ROOM 1389 START--
 The Sinking Colonnade
 1388,0,0,1390
-   A pungent scent hangs in the air. From the water, two glowing yellow eyes
- glare at you, unblinking.
+A pungent scent hangs in the air. From the water, two glowing yellow eyes glare at you, unblinking.
 --ROOM 1389 END--
 --ROOM 1390 START--
 The Sinking Colonnade
 1391,0,1389,0
-   A sudden cough from the darkness halts your steps. Instinctively, you draw
- your sword-only to find yourself face to face with a Ratcatcher.
+A sudden cough from the darkness halts your steps. Instinctively, you draw your sword-only to find yourself face to face with a Ratcatcher.
 --ROOM 1390 END--
 --ROOM 1391 START--
 The Sinking Colonnade
 0,1390,1388,0
-   A series of worn stone steps descend into the murky abyss below.
+A series of worn stone steps descend into the murky abyss below.
 --ROOM 1391 END--
 --ROOM 1392 START--
 The Sinking Colonnade
 0,0,1393,1386
-   The water parts as a grotesque Murgloth rises before you, its slimy form
- dripping with decay.
+The water parts as a grotesque Murgloth rises before you, its slimy form dripping with decay.
 --ROOM 1392 END--
 --ROOM 1393 START--
 The Sinking Colonnade
 1394,0,1399,1392
-   With every cautious step, you feel yourself plunging deeper into the
- unknown.
+With every cautious step, you feel yourself plunging deeper into the unknown.
 --ROOM 1393 END--
 --ROOM 1394 START--
 The Sinking Colonnade
 1395,1393,0,0
-   The ground quakes violently. Water rushes away, vanishing through unseen
- cracks below.
+The ground quakes violently. Water rushes away, vanishing through unseen cracks below.
 --ROOM 1394 END--
 --ROOM 1395 START--
 The Sinking Colonnade
 1396,1394,1398,0
-   You stand in silent awe-before you, a lost world lies frozen in time,
- untouched by the ages.
+You stand in silent awe-before you, a lost world lies frozen in time, untouched by the ages.
 --ROOM 1395 END--
 --ROOM 1396 START--
 The Sinking Colonnade
 0,1395,1397,1406
-   From the shadows, the faint rattle of unseen movement sends a chill down
- your spine.
+From the shadows, the faint rattle of unseen movement sends a chill down your spine.
 --ROOM 1396 END--
 --ROOM 1397 START--
 The Sinking Colonnade
 0,1398,0,1396
-   In the distance, a lone figure stands unnaturally still, its posture
- disturbingly rigid.
+In the distance, a lone figure stands unnaturally still, its posture disturbingly rigid.
 --ROOM 1397 END--
 --ROOM 1398 START--
 The Sinking Colonnade
 1397,0,0,1395
-   The sound of clattering bones erupts from the darkness, followed by a
- deathly wail. You recoil as a Skeleton Warrior lurches toward you.
+The sound of clattering bones erupts from the darkness, followed by a deathly wail. You recoil as a Skeleton Warrior lurches toward you.
 --ROOM 1398 END--
 --ROOM 1399 START--
 The Sinking Colonnade
 0,0,1400,1393
-   For a fleeting moment, you are consumed by the horror of this place-bones
- litter the ground, grim reminders of those who perished here.
+For a fleeting moment, you are consumed by the horror of this place-bones litter the ground, grim reminders of those who perished here.
 --ROOM 1399 END--
 --ROOM 1400 START--
 The Sinking Colonnade
 0,1401,0,1399
-   The lifeless bodies of lost souls drift upon the water, their hollow eyes
- staring into oblivion.
+The lifeless bodies of lost souls drift upon the water, their hollow eyes staring into oblivion.
 --ROOM 1400 END--
 --ROOM 1401 START--
 The Sinking Colonnade
 1400,1402,0,0
-   The ground trembles. Cracks split the chamber as the water drains away
- rising from the depths, a Marrowkrake emerges.
+The ground trembles. Cracks split the chamber as the water drains away rising from the depths, a Marrowkrake emerges.
 --ROOM 1401 END--
 --ROOM 1402 START--
 The Sinking Colonnade
 1401,1403,0,1405
-   The remains of the dead lie strewn across the floor, victims of a forgotten
- nightmare.
+The remains of the dead lie strewn across the floor, victims of a forgotten nightmare.
 --ROOM 1402 END--
 --ROOM 1403 START--
 The Sinking Colonnade
 1402,0,0,1404
-   Ancient carvings line the walls, depicting a history long buried beneath
- time.
+Ancient carvings line the walls, depicting a history long buried beneath time.
 --ROOM 1403 END--
 --ROOM 1404 START--
 The Sinking Colonnade
 1405,0,1403,0
-   The walls and floors are marred with deep, jagged scratches-the unmistakable
- marks of the Marrowkrake.
+The walls and floors are marred with deep, jagged scratches-the unmistakable marks of the Marrowkrake.
 --ROOM 1404 END--
 --ROOM 1405 START--
 The Sinking Colonnade
 0,1404,1402,0
-   A question lingers in your mind: What kind of being could have constructed
- such a forsaken place?
+A question lingers in your mind: What kind of being could have constructed such a forsaken place?
 --ROOM 1405 END--
 --ROOM 1406 START--
 The Sinking Colonnade
 1407,0,1396,0
-   From the abyss, brief flashes of light flicker-illuminating horrors just
- beyond your reach.
+From the abyss, brief flashes of light flicker-illuminating horrors just beyond your reach.
 --ROOM 1406 END--
 --ROOM 1407 START--
 The Sinking Colonnade
 1408,1406,0,0
-   The floor crumbles beneath you, plunging into the abyss. With a desperate
- leap, you grasp a staircase barely clinging to the ruins.
+The floor crumbles beneath you, plunging into the abyss. With a desperate leap, you grasp a staircase barely clinging to the ruins.
 --ROOM 1407 END--
 --ROOM 1408 START--
 The Sinking Colonnade
 1409,1407,1411,0
-   The ground beneath you is unstable, and every instinct screams at you to
- run.
+The ground beneath you is unstable, and every instinct screams at you to run.
 --ROOM 1408 END--
 --ROOM 1409 START--
 The Sinking Colonnade
 1412,1408,1410,0
-   Just ahead, a dark patch of water looms-a void that seems to drop into
- nothingness.
+Just ahead, a dark patch of water looms-a void that seems to drop into nothingness.
 --ROOM 1409 END--
 --ROOM 1410 START--
 The Sinking Colonnade
 0,1411,0,1409
-   Something slithers past your ankle, vanishing before you can react. Your
- heart pounds as you stumble backward.
+Something slithers past your ankle, vanishing before you can react. Your heart pounds as you stumble backward.
 --ROOM 1410 END--
 --ROOM 1411 START--
 The Sinking Colonnade
 1410,0,0,1408
-   Silence envelops you. The water is still. The world holds its breath.
+Silence envelops you. The water is still. The world holds its breath.
 --ROOM 1411 END--
 --ROOM 1412 START--
 The Withering Garden
 1413,1409,0,0
-   You stand before a long, overgrown hallway, its stone walls and floor
- completely consumed by creeping vines and moss.
+You stand before a long, overgrown hallway, its stone walls and floor completely consumed by creeping vines and moss.
 --ROOM 1412 END--
 --ROOM 1413 START--
 The Withering Garden
 0,1412,0,1414
-   Your footsteps echo through the corridor, each step a quiet reminder of your
- solitude.
+Your footsteps echo through the corridor, each step a quiet reminder of your solitude.
 --ROOM 1413 END--
 --ROOM 1414 START--
 The Withering Garden
 1415,0,1413,0
-   From behind a curtain of tangled vines and leaves, a Verdant Husk shambles
- forth, its form barely human.
+From behind a curtain of tangled vines and leaves, a Verdant Husk shambles forth, its form barely human.
 --ROOM 1414 END--
 --ROOM 1415 START--
 The Withering Garden
 1416,1414,0,1417
-   Vines hang from the ceiling, swaying gently as though stirred by an unseen
- breath.
+Vines hang from the ceiling, swaying gently as though stirred by an unseen breath.
 --ROOM 1415 END--
 --ROOM 1416 START--
 The Withering Garden
 0,1415,0,0
-   In the distance, a strange tree rises against the skyline-its twisted form
- unlike anything you've ever seen.
+In the distance, a strange tree rises against the skyline-its twisted form unlike anything you've ever seen.
 --ROOM 1416 END--
 --ROOM 1417 START--
 The Withering Garden
 0,0,1415,1418
-   With each step, you press deeper into the unknown, the dense foliage closing
- in around you.
+With each step, you press deeper into the unknown, the dense foliage closing in around you.
 --ROOM 1417 END--
 --ROOM 1418 START--
 The Withering Garden
 1419,0,1417,0
-   The ground suddenly gives way beneath you. You drop a few feet, landing hard
- on damp, unyielding earth.
+The ground suddenly gives way beneath you. You drop a few feet, landing hard on damp, unyielding earth.
 --ROOM 1418 END--
 --ROOM 1419 START--
 The Withering Garden
 1420,1418,0,0
-   A narrow path is carved into the wet earth, the only break in an otherwise
- impenetrable thicket.
+A narrow path is carved into the wet earth, the only break in an otherwise impenetrable thicket.
 --ROOM 1419 END--
 --ROOM 1420 START--
 The Withering Garden
 1423,1419,0,1421
-   You freeze mid-step. Turning, you find Selith standing before you, his gaze
- unreadable.
+You freeze mid-step. Turning, you find Selith standing before you, his gaze unreadable.
 --ROOM 1420 END--
 --ROOM 1421 START--
 The Withering Garden
 1422,0,1420,0
-   Everything here feels displaced-trapped in a forgotten time, untouched by
- the world beyond.
+Everything here feels displaced-trapped in a forgotten time, untouched by the world beyond.
 --ROOM 1421 END--
 --ROOM 1422 START--
 The Withering Garden
 0,1421,1423,0
-   You push through the thick underbrush, emerging onto another hidden trail.
+You push through the thick underbrush, emerging onto another hidden trail.
 --ROOM 1422 END--
 --ROOM 1423 START--
 The Withering Garden
 1424,1420,0,1422
-   The entrance to a hidden temple looms before you, skeletal remains hanging
- from the twisted branches above.
+The entrance to a hidden temple looms before you, skeletal remains hanging from the twisted branches above.
 --ROOM 1423 END--
 --ROOM 1424 START--
 The Withering Garden
 1425,1423,0,0
-   A lone bird's call echoes through the jungle, its cry distant yet hauntingly
- clear.
+A lone bird's call echoes through the jungle, its cry distant yet hauntingly clear.
 --ROOM 1424 END--
 --ROOM 1425 START--
 The Withering Garden
 1426,1424,0,1433
-   You arrive at a fork in the path-two diverging roads, each leading into an
- uncertain future.
+You arrive at a fork in the path-two diverging roads, each leading into an uncertain future.
 --ROOM 1425 END--
 --ROOM 1426 START--
 The Withering Garden
 1427,1425,0,0
-   Strange figures, ancient and unknowable, are carved into the stone walls.
+Strange figures, ancient and unknowable, are carved into the stone walls.
 --ROOM 1426 END--
 --ROOM 1427 START--
 The Withering Garden
 0,1426,1428,0
-   Chains hang from the ceiling, swaying in the howling wind, their metallic
- clatter unsettling in the darkness.
+Chains hang from the ceiling, swaying in the howling wind, their metallic clatter unsettling in the darkness.
 --ROOM 1427 END--
 --ROOM 1428 START--
 The Withering Garden
 1429,0,0,1427
-   The walls tremble, then inch inward-closing the space around you with
- deliberate menace.
+The walls tremble, then inch inward-closing the space around you with deliberate menace.
 --ROOM 1428 END--
 --ROOM 1429 START--
 The Withering Garden
 1432,1428,1430,0
-   Beneath your feet, the floor lurches, grinding along unseen rails as rusted
- gears scream in protest.
+Beneath your feet, the floor lurches, grinding along unseen rails as rusted gears scream in protest.
 --ROOM 1429 END--
 --ROOM 1430 START--
 The Withering Garden
 1431,0,1440,1429
-   With every jolt in the path, dust erupts from the floor in thick, choking
- clouds.
+With every jolt in the path, dust erupts from the floor in thick, choking clouds.
 --ROOM 1430 END--
 --ROOM 1431 START--
 The Withering Garden
 0,1430,0,1432
-   A viscous slime oozes from the cracks in the floor, creeping forward like a
- predator hunting its next meal.
+A viscous slime oozes from the cracks in the floor, creeping forward like a predator hunting its next meal.
 --ROOM 1431 END--
 --ROOM 1432 START--
 The Withering Garden
 0,1429,1431,0
-   A lone globe stands at the center of the chamber, its surface worn yet
- pulsing with mystery.
+A lone globe stands at the center of the chamber, its surface worn yet pulsing with mystery.
 --ROOM 1432 END--
 --ROOM 1433 START--
 The Withering Garden
 0,0,1425,1434
-   You stand before a massive statue of a forgotten god-its offerings long
- reduced to dust and cobwebs.
+You stand before a massive statue of a forgotten god-its offerings long reduced to dust and cobwebs.
 --ROOM 1433 END--
 --ROOM 1434 START--
 The Withering Garden
 1435,0,1433,0
-   From the earth itself, a liquid creature rises, its form shifting as if
- recalling the shape of a once-living being.
+From the earth itself, a liquid creature rises, its form shifting as if recalling the shape of a once-living being.
 --ROOM 1434 END--
 --ROOM 1435 START--
 The Withering Garden
 0,1434,0,1436
-   The floor crumbles beneath you, revealing a writhing mass of skeletal hands,
- each clawing desperately to pull you under.
+The floor crumbles beneath you, revealing a writhing mass of skeletal hands, each clawing desperately to pull you under.
 --ROOM 1435 END--
 --ROOM 1436 START--
 The Withering Garden
 1439,0,1435,1437
-   Without warning, a set of stairs unfolds from the walls, their destination
- shrouded in uncertainty.
+Without warning, a set of stairs unfolds from the walls, their destination shrouded in uncertainty.
 --ROOM 1436 END--
 --ROOM 1437 START--
 The Withering Garden
 1438,0,1436,0
-   A raven dives toward you, talons extended. You lunge backward just in time.
+A raven dives toward you, talons extended. You lunge backward just in time.
 --ROOM 1437 END--
 --ROOM 1438 START--
 The Withering Garden
 0,1437,1439,0
-   From the darkness, a silhouette emerges-the faint outline of a person
- hanging motionless from a frayed rope.
+From the darkness, a silhouette emerges-the faint outline of a person hanging motionless from a frayed rope.
 --ROOM 1438 END--
 --ROOM 1439 START--
 The Withering Garden
 0,1436,0,1438
-   Reaching the top of the stairs, you pause. Below, the world stretches vast
- and unknowable before you.
+Reaching the top of the stairs, you pause. Below, the world stretches vast and unknowable before you.
 --ROOM 1439 END--
 --ROOM 1440 START--
 The God's Crypt
 0,0,1441,1430
-   You stand before the yawning maw of this forsaken place, its hollowed
- entrance a gaping wound in the ancient stone. A cold wind whispers through the
- cracks, sending an involuntary shiver down your spine.
+You stand before the yawning maw of this forsaken place, its hollowed entrance a gaping wound in the ancient stone. A cold wind whispers through the cracks, sending an involuntary shiver down your spine.
 --ROOM 1440 END--
 --ROOM 1441 START--
 The God's Crypt
 1442,0,0,1440
-   Your lantern sputters, its weak glow trembling against the oppressive warmth
- of the stagnant air.
+Your lantern sputters, its weak glow trembling against the oppressive warmth of the stagnant air.
 --ROOM 1441 END--
 --ROOM 1442 START--
 The God's Crypt
 1443,1441,0,0
-   With a slow, grinding groan, a stone wall begins to descend, unveiling a
- chamber untouched by time-forgotten, yet waiting.
+With a slow, grinding groan, a stone wall begins to descend, unveiling a chamber untouched by time-forgotten, yet waiting.
 --ROOM 1442 END--
 --ROOM 1443 START--
 The God's Crypt
 1444,1442,0,0
-   Dust and cobwebs cling to the walls and dangle from the ceiling, remnants of
- ages abandoned to silence.
+Dust and cobwebs cling to the walls and dangle from the ceiling, remnants of ages abandoned to silence.
 --ROOM 1443 END--
 --ROOM 1444 START--
 The God's Crypt
 0,1443,1445,0
-   The silence here is thick, suffocating. It presses against you like an
- unseen force, deafening in its weight.
+The silence here is thick, suffocating. It presses against you like an unseen force, deafening in its weight.
 --ROOM 1444 END--
 --ROOM 1445 START--
 The God's Crypt
 1453,0,1446,1444
-   You move cautiously, each step measured, unwilling to break the uneasy hush
- that clings to this forsaken place.
+You move cautiously, each step measured, unwilling to break the uneasy hush that clings to this forsaken place.
 --ROOM 1445 END--
 --ROOM 1446 START--
 The God's Crypt
 0,0,1447,1445
-   Everything here reeks of death-an emptiness so profound that even decay has
- long since abandoned it.
+Everything here reeks of death-an emptiness so profound that even decay has long since abandoned it.
 --ROOM 1446 END--
 --ROOM 1447 START--
 The God's Crypt
 0,0,1448,1446
-   Stone slabs rest in solemn rows, each bearing skeletal remains shrouded in
- mystery. No names, no histories-only the stillness of the unknown.
+Stone slabs rest in solemn rows, each bearing skeletal remains shrouded in mystery. No names, no histories-only the stillness of the unknown.
 --ROOM 1447 END--
 --ROOM 1448 START--
 The God's Crypt
 0,1449,0,1447
-   You freeze. A voice-a woman's-echoes faintly through the passage, speaking
- to another unseen presence.
+You freeze. A voice-a woman's-echoes faintly through the passage, speaking to another unseen presence.
 --ROOM 1448 END--
 --ROOM 1449 START--
 The God's Crypt
 1448,1452,0,1450
-   In the stifling darkness, the flickering glow of torches dances at the edge
- of your vision, their feeble light offering little comfort.
+In the stifling darkness, the flickering glow of torches dances at the edge of your vision, their feeble light offering little comfort.
 --ROOM 1449 END--
 --ROOM 1450 START--
 The God's Crypt
 0,1451,1449,0
-   From your vantage point on a wooden platform, you see her-the leader of this
- clandestine gathering. Cloaked figures listen in silence as she speaks, her
- words lost to the shadows.
+From your vantage point on a wooden platform, you see her-the leader of this clandestine gathering. Cloaked figures listen in silence as she speaks, her words lost to the shadows.
 --ROOM 1450 END--
 --ROOM 1451 START--
 The God's Crypt
 1450,0,1452,0
-   A gaping pit yawns in the center of the chamber, its depths unknowable. The
- stones lining its edge are dark and stained-whether by age or something more
- sinister, you cannot say.
+A gaping pit yawns in the center of the chamber, its depths unknowable. The stones lining its edge are dark and stained-whether by age or something more sinister, you cannot say.
 --ROOM 1451 END--
 --ROOM 1452 START--
 The God's Crypt
 1449,0,0,1451
-   Before you stands a monolithic stone, its surface etched with ancient
- carvings. The walls surrounding it are adorned with cryptic symbols, hinting
- at something concealed beyond.
+Before you stands a monolithic stone, its surface etched with ancient carvings. The walls surrounding it are adorned with cryptic symbols, hinting at something concealed beyond.
 --ROOM 1452 END--
 --ROOM 1453 START--
 The God's Crypt
 1454,1445,0,0
-   The ground trembles as the walls shudder, slowly sinking into the floor. A
- hidden chamber reveals itself, veiled in dust and secrecy.
+The ground trembles as the walls shudder, slowly sinking into the floor. A hidden chamber reveals itself, veiled in dust and secrecy.
 --ROOM 1453 END--
 --ROOM 1454 START--
 The God's Crypt
 1455,1453,0,1456
-   Standing motionless before you is the God's Guard, his golden armor gleaming
- even in the dim light. How long he has stood his silent vigil is anyone's
- guess.
+Standing motionless before you is the God's Guard, his golden armor gleaming even in the dim light. How long he has stood his silent vigil is anyone's guess.
 --ROOM 1454 END--
 --ROOM 1455 START--
 The God's Crypt
 0,1454,0,0
-   At the center of the chamber, a single stone throne sits in solemn
- isolation, its presence commanding yet eerily vacant.
+At the center of the chamber, a single stone throne sits in solemn isolation, its presence commanding yet eerily vacant.
 --ROOM 1455 END--
 --ROOM 1456 START--
 The God's Crypt
 0,0,1454,1457
-   You tread carefully through a labyrinth of ancient inscriptions, the walls
- alive with forgotten stories etched in stone.
+You tread carefully through a labyrinth of ancient inscriptions, the walls alive with forgotten stories etched in stone.
 --ROOM 1456 END--
 --ROOM 1457 START--
 The God's Crypt
 1458,0,1456,0
-   Beneath your foot, the floor shifts. A section begins to sink, pulling you
- downward into the unknown.
+Beneath your foot, the floor shifts. A section begins to sink, pulling you downward into the unknown.
 --ROOM 1457 END--
 --ROOM 1458 START--
 The God's Crypt
 1459,1457,0,0
-   High above, a faint light flickers-a fragile glow lost amidst the
- encroaching darkness.
+High above, a faint light flickers-a fragile glow lost amidst the encroaching darkness.
 --ROOM 1458 END--
 --ROOM 1459 START--
 The God's Crypt
 1460,1458,0,0
-   A wide staircase unfurls before you, its steps worn by countless feet long
- since turned to dust.
+A wide staircase unfurls before you, its steps worn by countless feet long since turned to dust.
 --ROOM 1459 END--
 --ROOM 1460 START--
 The God's Crypt
 1463,1459,1461,1462
-   At your feet, a vast opening gapes in the floor, plunging into an abyss
- without end.
+At your feet, a vast opening gapes in the floor, plunging into an abyss without end.
 --ROOM 1460 END--
 --ROOM 1461 START--
 The God's Crypt
 0,0,0,1460
-   Rows of empty cells line the corridor, their iron doors corroded and
- crumbling, rust consuming their forgotten purpose.
+Rows of empty cells line the corridor, their iron doors corroded and crumbling, rust consuming their forgotten purpose.
 --ROOM 1461 END--
 --ROOM 1462 START--
 The God's Crypt
 0,0,1460,0
-   Empty cells stand locked in eerie defiance, their secrets trapped behind
- iron bars left to rot in time's embrace.
+Empty cells stand locked in eerie defiance, their secrets trapped behind iron bars left to rot in time's embrace.
 --ROOM 1462 END--
 --ROOM 1463 START--
 The God's Crypt
 1464,1460,0,0
-   A foul stench hangs in the stagnant air, thick and oppressive. The uneasy
- feeling of unseen eyes crawling over you refuses to fade.
+A foul stench hangs in the stagnant air, thick and oppressive. The uneasy feeling of unseen eyes crawling over you refuses to fade.
 --ROOM 1463 END--
 --ROOM 1464 START--
 The God's Crypt
 0,1463,1465,1466
-   You stand before an archway unlike any other-its surface rippling like
- liquid silver, shifting with an unnatural stillness.
+You stand before an archway unlike any other-its surface rippling like liquid silver, shifting with an unnatural stillness.
 --ROOM 1464 END--
 --ROOM 1465 START--
 The God's Crypt
 0,0,0,1464
-   A guard looms before you, gripping a prisoner whose wrists are bound tight
- with rope. The captive's expression is unreadable.
+A guard looms before you, gripping a prisoner whose wrists are bound tight with rope. The captive's expression is unreadable.
 --ROOM 1465 END--
 --ROOM 1466 START--
 The God's Crypt
 0,0,1464,0
-   A long wooden table is strewn with haphazardly opened books and scattered
- papers. Whoever was here was working feverishly-until they weren't.
+A long wooden table is strewn with haphazardly opened books and scattered papers. Whoever was here was working feverishly-until they weren't.
 --ROOM 1466 END--


### PR DESCRIPTION
Modifies the room descriptions to all be on the same line, reducing built-in linebreaks.
Adds a function called PrintWrapSafe that will handle making sure words don't get cut off during print.

![image](https://github.com/user-attachments/assets/23f8fb4c-abf6-4958-a460-cd2789300be8)
